### PR TITLE
feat(bdev): implements `BDevIo::allocate_buffers` API

### DIFF
--- a/spdk/src/bdev/mod.rs
+++ b/spdk/src/bdev/mod.rs
@@ -25,6 +25,8 @@ pub use bdev::{
     IoStatus,
     IoType,
 };
+#[cfg(feature = "bdev-module")]
+pub(crate) use bdev::BDevIoCtx;
 
 #[cfg(feature = "bdev-module")]
 pub use module::{

--- a/spdk/src/bdev/module.rs
+++ b/spdk/src/bdev/module.rs
@@ -25,7 +25,8 @@ use crate::{
 
 use super::{
     BDevImpl,
-    BDevOps
+    BDevIoCtx,
+    BDevOps,
 };
 
 
@@ -37,7 +38,7 @@ pub trait ModuleOps {
     ///
     /// [`BDevIo::ctx()`]: method@super::BDevIo::ctx
     /// [`BDevIo::ctx_mut()`]: method@super::BDevIo::ctx_mut
-    type IoContext;
+    type IoContext: Default + 'static;
 
     /// Initializes the module.
     async fn init(&self) {
@@ -49,7 +50,7 @@ pub trait ModuleOps {
 
     /// Returns the size of the per-I/O context.
     fn get_io_context_size(&self) -> usize {
-        size_of::<Self::IoContext>()
+        size_of::<BDevIoCtx<Self::IoContext>>()
     }
 
     /// Examines the specified block device to determine whether it should be

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -216,8 +216,6 @@ where
                         let state = self.state.lock().unwrap().poll(cx);
 
                         if let PromiseState::Kept(res) = state {
-                            unsafe { Arc::from_raw(promise_cx) };
-
                             return Poll::Ready(res);
                         }
 

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -123,6 +123,16 @@ impl Thread {
         }
     }
 
+    /// Returns a borrowed thread object for the specified non-null pointer.
+    ///
+    /// # Safety
+    /// 
+    /// The caller must ensure that `thread` is non-null and points to a valid
+    /// `spdk_thread` object.
+    pub unsafe fn from_ptr_unchecked(thread: *mut spdk_thread) -> Self {
+        Self(OwnershipState::Borrowed(NonNull::new_unchecked(thread)))
+    }
+
     /// Returns the borrowed thread with the specified unique identifier.
     pub fn from_id(id: u64) -> Option<Self> {
         unsafe {


### PR DESCRIPTION
Implements the `BDevIo::allocate_buffers` API to ensure I/O buffers are allocated and properly aligned per the BDev implementations alignment requirement.

Fixes a double-free of the `Promise` state if the start function's callback is invoked before it returns.