### PR TITLE
chore: ensure I/O completion on return from submit_request

### DIFF
--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -19,6 +19,7 @@ static_init = "1.0.3"
 ternary-rs = "1.0.0"
 
 [dev-dependencies]
+async-std = { version = "1.12.0", features = ["unstable"] }
 byte-strings= "0.3.1"
 
 [features]

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -7,7 +7,6 @@ use spdk::{
         BDevIo,
         BDevIoChannelOps,
         BDevOps,
-        IoStatus,
         IoType,
         ModuleInstance,
         ModuleOps,
@@ -38,14 +37,14 @@ struct NullRsChannel;
 impl BDevIoChannelOps for NullRsChannel {
     type IoContext = ();
 
-    async fn submit_request(&self, io: BDevIo<Self::IoContext>) {
+    async fn submit_request(&self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
         if io.io_type() == IoType::Read {
             let dst = io.buffers_mut();
 
             dst[0].fill(0);
         }
 
-        io.complete(IoStatus::Success);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR changes the `BDevIoChannelOps::submit_request` method to return a `Result<(), Errno>` instead of completing the `BDevIo<T>` manually. The `BDevImpl<T>` implementation will complete the I/O based on the returned result. This reduces the chance of orphaning an I/O by accidentally not completing it.