### PR TITLE
chore: improve I/O channel management

### DIFF
--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -75,7 +75,6 @@ struct EchoInner {
 /// Implements the Echo block device I/O channel. Each read request is paired
 /// with a write request. The read request is completed with the data from the
 /// write request and the write request completed when read.
-#[derive(Default)]
 struct EchoChannel {
     device: Arc<EchoInner>
 }
@@ -182,8 +181,10 @@ impl BDevOps for Echo {
         }
     }
 
-    fn prepare_io_channel(&mut self, channel: &mut EchoChannel) {
-        channel.device = self.inner.clone();
+    fn new_io_channel(&mut self) -> Result<EchoChannel, Errno> {
+        let device = self.inner.clone();
+
+        Ok(EchoChannel{ device })
     }
 }
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -30,7 +30,7 @@ impl ModuleOps for NullRsModule {
 
 /// Implements the NullRs block device I/O channel. It ignores write requests
 /// and returns zeroed buffers for read requests.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct NullRsChannel;
 
 #[async_trait]
@@ -79,6 +79,10 @@ impl BDevOps for NullRs {
 
     fn io_type_supported(&self, io_type: IoType) -> bool {
         matches!(io_type, IoType::Read | IoType::Write)
+    }
+
+    fn new_io_channel(&mut self) -> Result<NullRsChannel, Errno> {
+        Ok(NullRsChannel)
     }
 }
 


### PR DESCRIPTION
This PR removes the requirement that `BDevIoChannelOps` implement the `Default` trait, enables graceful handling of I/O channel allocation/initialization failure and improves safety preventing inadvertent conversions to/from invalid raw `spdk_io_channel` pointers.