### PR TITLE
feat: add bdev feature to spdk crate

### DIFF
--- a/spdk-sys/wrapper.h
+++ b/spdk-sys/wrapper.h
@@ -1,9 +1,12 @@
-#include "spdk/bdev.h"
-#include "spdk/bdev_zone.h"
 #include "spdk/cpuset.h"
 #include "spdk/env.h"
 #include "spdk/event.h"
 #include "spdk/thread.h"
+
+#if defined(CARGO_FEATURE_BDEV)
+#include "spdk/bdev.h"
+#include "spdk/bdev_zone.h"
+#endif
 
 #if defined(CARGO_FEATURE_BDEV_MODULE)
 #include "spdk/bdev_module.h"

--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -24,9 +24,10 @@ byte-strings= "0.3.1"
 
 [features]
 default = []
-bdev-malloc = ["spdk-sys/bdev-malloc"]
-bdev-module = ["spdk-macros/bdev-module", "spdk-sys/bdev-module"]
-nvmf = ["spdk-sys/nvmf"]
+bdev = ["spdk-sys/bdev"]
+bdev-malloc = ["bdev", "spdk-sys/bdev-malloc"]
+bdev-module = ["bdev", "spdk-macros/bdev-module", "spdk-sys/bdev-module"]
+nvmf = ["bdev","spdk-sys/nvmf"]
 
 [[example]]
 name = "bdev_hello_world"

--- a/spdk/src/block/mod.rs
+++ b/spdk/src/block/mod.rs
@@ -1,4 +1,5 @@
 //! Support for Storage Performance Development Kit block devices.
+#![cfg(feature = "bdev")]
 mod any;
 mod descriptor;
 mod device;


### PR DESCRIPTION
Adds a `bdev` feature to the `spdk` crate and hides the `bdev`-specific definitions behind it.