### PR TITLE
chore: use Rust native C-string literals

### DIFF
--- a/spdk-macros/Cargo.toml
+++ b/spdk-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spdk-macros"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,7 +10,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-byte-strings = "0.3.1"
 convert_case = "0.6.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"

--- a/spdk-macros/src/lib.rs
+++ b/spdk-macros/src/lib.rs
@@ -203,7 +203,6 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// use std::io::Write;
 ///
 /// use async_trait::async_trait;
-/// use byte_strings::c_str;
 /// use spdk::{
 ///     bdev::{
 ///         BDevIo,
@@ -260,7 +259,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// impl NullRs {
 ///     /// Creates a new NullRs block device.
 ///     pub fn try_new() -> Result<Device<Owned>, Errno> {
-///         let mut null = NullRsModule::new_bdev(c_str!("null-rs"), NullRs::default());
+///         let mut null = NullRsModule::new_bdev(c"null-rs", NullRs::default());
 ///
 ///         null.bdev.blocklen = 4096;
 ///         null.bdev.blockcnt = 1;

--- a/spdk-macros/src/module.rs
+++ b/spdk-macros/src/module.rs
@@ -1,6 +1,9 @@
+use std::ffi::CString;
+
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
+use syn::LitCStr;
 
 pub(crate) struct GenerateModule {
 }
@@ -14,30 +17,39 @@ impl GenerateModule {
     /// Generates the code for the `module` attribute macro.
     pub(crate) fn generate(&mut self, _attr: TokenStream, item: TokenStream) -> TokenStream {
         let input = syn::parse_macro_input!(item as syn::ItemStruct);
-        let module = input.ident.clone();
-        let module_name = input.ident.to_string().trim_end_matches("Module").from_case(Case::UpperCamel).to_case(Case::Snake);
-        let reg_var_name = module_name.from_case(Case::Snake).to_case(Case::UpperSnake);
-        let reg_var = syn::Ident::new(&reg_var_name, module.span());
+        let module_ident = input.ident.clone();
+        let module_name = input.ident
+            .to_string()
+            .trim_end_matches("Module")
+            .from_case(Case::UpperCamel)
+            .to_case(Case::Snake);
+        let module_ident_name = module_name.from_case(Case::Snake).to_case(Case::UpperSnake);
+        let reg_var_ident = format_ident!("__{}_MODULE", module_ident_name);
+        let module_name_ident = format_ident!("__{}_MODULE_NAME", module_ident_name);
+        let module_name_cstr = CString::new(module_name).unwrap();
+        let module_name_lit = LitCStr::new(&module_name_cstr, module_ident.span());
 
         let output = quote!{
             #input
 
-            static #reg_var: ::std::sync::OnceLock<::spdk::bdev::Module<#module>> = ::std::sync::OnceLock::new();
+            static #reg_var_ident: ::std::sync::OnceLock<::spdk::bdev::Module<#module_ident>> = ::std::sync::OnceLock::new();
+
+            const #module_name_ident: &::std::ffi::CStr = #module_name_lit;
 
             #[static_init::constructor]
             extern "C" fn register() {
-                #reg_var.set(::spdk::bdev::Module::new(::byte_strings::c_str!(#module_name))).unwrap();
+                #reg_var_ident.set(::spdk::bdev::Module::new(#module_name_ident)).unwrap();
 
-                #reg_var.get().unwrap().register();
+                #reg_var_ident.get().unwrap().register();
             }
 
-            impl ::spdk::bdev::ModuleInstance<#module> for #module {
-                fn instance() -> &'static #module {
-                    &#reg_var.get().unwrap().instance
+            impl ::spdk::bdev::ModuleInstance<#module_ident> for #module_ident {
+                fn instance() -> &'static #module_ident {
+                    &#reg_var_ident.get().unwrap().instance
                 }
 
                 fn module() -> *const ::spdk_sys::spdk_bdev_module {
-                    &#reg_var.get().unwrap().module as *const _
+                    &#reg_var_ident.get().unwrap().module as *const _
                 }
 
                 fn new_bdev<B>(name: &::std::ffi::CStr, ctx: B) -> Box<::spdk::bdev::BDevImpl<B>>

--- a/spdk-sys/Cargo.toml
+++ b/spdk-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spdk-sys"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.77.0"
 links = "spdk"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spdk"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.77.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -9,7 +10,6 @@ all-features = true
 [dependencies]
 aquamarine = "0.5.0"
 async-trait = "0.1.74"
-byte-strings = "0.3.1"
 errno = "0.3.9"
 futures = "0.3.30"
 libc = "0.2.155"

--- a/spdk/examples/bdev_hello_world.rs
+++ b/spdk/examples/bdev_hello_world.rs
@@ -6,14 +6,13 @@ use std::{
     },
 };
 
-use byte_strings::c_str;
 use spdk::{
     bdev::malloc,
     dma,
     thread,
 };
 
-const BDEV_NAME: &CStr = c_str!("Malloc0");
+const BDEV_NAME: &CStr = c"Malloc0";
 const NUM_BLOCKS: u64 = 32768;
 const BLOCK_SIZE: u32 = 512;
 

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -14,7 +14,6 @@ use async_std::sync::{
     Mutex,
 };
 use async_trait::async_trait;
-use byte_strings::c_str;
 use futures::future::join;
 use spdk::{
     bdev::{
@@ -198,7 +197,7 @@ async fn main() {
         panic!("ERROR: At least two cores must be specified.")
     }
 
-    let echo = Echo::try_new(c_str!("echo")).unwrap();
+    let echo = Echo::try_new(c"echo").unwrap();
 
     let echo_writer = echo.borrow();
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 use async_trait::async_trait;
-use byte_strings::c_str;
 use spdk::{
     bdev::{
         BDevIo,
@@ -58,7 +57,7 @@ unsafe impl Sync for NullRs {}
 impl NullRs {
     /// Creates a new NullRs block device.
     pub fn try_new() -> Result<Device<Owned>, Errno> {
-        let mut null = NullRsModule::new_bdev(c_str!("null-rs"), NullRs::default());
+        let mut null = NullRsModule::new_bdev(c"null-rs", NullRs::default());
 
         null.bdev.blocklen = 4096;
         null.bdev.blockcnt = 1;

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use byte_strings::c_str;
 use spdk::{
     bdev::{
         BDevIo,
@@ -138,7 +137,7 @@ impl PassthruRs {
     }
 }
 
-const BDEV_NAME: &CStr = c_str!("Malloc0");
+const BDEV_NAME: &CStr = c"Malloc0";
 const NUM_BLOCKS: u64 = 32768;
 const BLOCK_SIZE: u32 = 512;
 

--- a/spdk/examples/nvmf.rs
+++ b/spdk/examples/nvmf.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use byte_strings::c_str;
 use spdk::{
     bdev::malloc,
     cli::Parser,
@@ -20,11 +19,11 @@ use spdk::{
 };
 use ternary_rs::if_else;
 
-const BDEV_NAME: &CStr = c_str!("Malloc0");
+const BDEV_NAME: &CStr = c"Malloc0";
 const NUM_BLOCKS: u64 = 32768;
 const BLOCK_SIZE: u32 = 512;
 
-const NQN: &CStr = c_str!("nqn.2016-06.io.spdk:cnode1");
+const NQN: &CStr = c"nqn.2016-06.io.spdk:cnode1";
 
 #[derive(Parser)]
 struct Args {

--- a/spdk/src/runtime/runtime.rs
+++ b/spdk/src/runtime/runtime.rs
@@ -176,11 +176,10 @@ impl Builder {
     /// # Examples
     /// 
     /// ```no_run
-    /// use byte_strings::c_str;
     /// use spdk::runtime::Builder;
     /// use std::ffi::CStr;
     /// 
-    /// const MY_APP_NAME: &CStr = c_str!("my_app");
+    /// const MY_APP_NAME: &CStr = c"my_app";
     /// 
     /// fn main() {
     ///     let rt = Builder::new()
@@ -278,11 +277,10 @@ impl Runtime {
     /// # Examples
     /// 
     /// ```no_run
-    /// use byte_strings::c_str;
     /// use spdk::runtime::Runtime;
     /// use std::ffi::CStr;
     /// 
-    /// const MY_APP_NAME: &CStr = c_str!("my_app");
+    /// const MY_APP_NAME: &CStr = c"my_app";
     /// 
     /// fn main() {
     ///     let rt = Runtime::new();


### PR DESCRIPTION
Rust 1.77.0 added native support for C-string literals. This PR replaces usage of the `byte-strings` crate with them.

As a result, the minimum required Rust version is now 1.77.0.
