### PR TITLE
feat: allow for !`Send` futures to be sent to other SPDK reactors and threads

### DIFF
--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -196,7 +196,7 @@ async fn main() {
 
     let echo_writer = echo.borrow();
 
-    let write_task = reactors[0].spawn(async move {
+    let write_task = reactors[0].spawn(move || async move {
         let writer = echo_writer.open(true).await.unwrap();
         let writer_ch = writer.io_channel().unwrap();
         let layout = writer.device().layout_for_blocks(1).unwrap();
@@ -215,7 +215,7 @@ async fn main() {
 
     let echo_reader = echo.borrow();
 
-    let read_task = reactors[1].spawn(async move {
+    let read_task = reactors[1].spawn(move || async move {
         let reader = echo_reader.open(true).await.unwrap();
         let reader_ch = reader.io_channel().unwrap();
         let layout = reader.device().layout_for_blocks(1).unwrap();

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -41,14 +41,9 @@ use spdk::{
 /// Implements the Echo block device module.
 #[spdk::module]
 #[derive(Debug, Default)]
-struct EchoModule {
+struct EchoModule;
 
-}
-
-unsafe impl Send for EchoModule {}
-unsafe impl Sync for EchoModule {}
-
-#[async_trait]
+#[async_trait(?Send)]
 impl ModuleOps for EchoModule {
     type IoContext = ();
 

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -125,7 +125,7 @@ impl EchoChannel {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl BDevIoChannelOps for EchoChannel {
     type IoContext = ();
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -32,7 +32,7 @@ impl ModuleOps for NullRsModule {
 #[derive(Debug)]
 struct NullRsChannel;
 
-#[async_trait]
+#[async_trait(?Send)]
 impl BDevIoChannelOps for NullRsChannel {
     type IoContext = ();
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -23,13 +23,13 @@ use spdk::{
 #[derive(Debug, Default)]
 struct NullRsModule;
 
+#[async_trait(?Send)]
 impl ModuleOps for NullRsModule {
     type IoContext = ();
 }
 
 /// Implements the NullRs block device I/O channel. It ignores write requests
 /// and returns zeroed buffers for read requests.
-#[derive(Debug)]
 struct NullRsChannel;
 
 #[async_trait(?Send)]

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -43,11 +43,11 @@ use spdk::{
 #[derive(Debug, Default)]
 struct PassthruRsModule;
 
+#[async_trait(?Send)]
 impl ModuleOps for PassthruRsModule {
     type IoContext = ();
 }
 
-#[derive(Debug)]
 struct PassthruRsChannel {
     ch: IoChannel
 }

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -52,7 +52,7 @@ struct PassthruRsChannel {
     ch: IoChannel
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl BDevIoChannelOps for PassthruRsChannel {
     type IoContext = ();
 

--- a/spdk/examples/reactor.rs
+++ b/spdk/examples/reactor.rs
@@ -16,7 +16,7 @@ async fn main() {
     let tasks = reactors()
         .map(
             |r| {
-                r.spawn(async {
+                r.spawn(|| async {
                     let core_id = Reactor::current().core().id();
 
                     time::sleep(Duration::from_secs(1 * core_id as u64)).await;

--- a/spdk/examples/thread.rs
+++ b/spdk/examples/thread.rs
@@ -14,13 +14,13 @@ async fn main() {
             |r| {
                 let core = r.core();
 
-                r.spawn(async move {
+                r.spawn(move || async move {
                     // Create a new thread on the current reactor's core and
                     // spawn a a task on it.
                     let name = CString::new(format!("thread_{}", core.id())).unwrap();
                     let t = Thread::new(name.as_c_str(), &core.into()).unwrap();
 
-                    t.spawn(async move {
+                    t.spawn(move || async move {
                         time::sleep(Duration::from_secs(1 * core.id() as u64)).await;
 
                         println!("Hello, World from {}!", Thread::current().name().to_string_lossy());

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -179,7 +179,7 @@ impl Into<spdk_bdev_io_status> for IoStatus {
 }
 
 /// A trait for implementing the I/O channel operations for a BDev.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait BDevIoChannelOps: 'static {
     /// The I/O context type for the BDev.
     type IoContext: Default + 'static;
@@ -286,8 +286,6 @@ where
     io: NonNull<spdk_bdev_io>,
     _ctx: PhantomData<T>
 }
-
-unsafe impl <T: Default + 'static> Send for BDevIo<T> {}
 
 impl <T> BDevIo<T>
 where

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -87,7 +87,6 @@ use crate::{
         EINPROGRESS,
         ENOMEM
     },
-    runtime::Reactor,
     task::{
         self,
 
@@ -605,7 +604,7 @@ where
 
     /// Destroys the BDev instance.
     unsafe extern "C" fn destruct(ctx: *mut c_void) -> i32 {
-        Reactor::current().spawn(async move {
+        thread::spawn_local(async move {
             let mut this = Self::from_ctx_ptr(ctx as *mut T);
 
             let rc = match this.ctx.destruct().await {

--- a/spdk/src/block/io_channel.rs
+++ b/spdk/src/block/io_channel.rs
@@ -87,9 +87,6 @@ pub struct IoChannel {
     channel: NonNull<spdk_io_channel>,
 }
 
-unsafe impl Send for IoChannel {}
-unsafe impl Sync for IoChannel {}
-
 impl IoChannel {
     /// Creates a new [`IoChannel`].
     pub(crate) fn new(desc: &Descriptor) -> Result<Self, Errno> {

--- a/spdk/src/runtime/mod.rs
+++ b/spdk/src/runtime/mod.rs
@@ -15,6 +15,7 @@ pub use cpu_set::CpuSet;
 
 pub use reactor::Reactor;
 pub use reactor::reactors;
+pub use reactor::spawn_local;
 
 pub use runtime::Builder;
 pub use runtime::Runtime;

--- a/spdk/src/runtime/reactor.rs
+++ b/spdk/src/runtime/reactor.rs
@@ -192,6 +192,20 @@ impl Reactor {
     }
 }
 
+/// Spawns a new asynchronous task to be executed on the current SPDK reactor and
+/// returns a [`JoinHandle`] to await results.
+pub fn spawn_local<F, T>(fut: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static
+{
+    let (task, join_handle) = ReactorTask::with_future(Reactor::current(), fut);
+
+    Task::schedule(task);
+
+    join_handle
+}
+
 /// An iterator over the reactors for this runtime.
 pub type Reactors = Map<CpuCores, fn(CpuCore) -> Reactor>;
 

--- a/spdk/src/runtime/reactor.rs
+++ b/spdk/src/runtime/reactor.rs
@@ -15,13 +15,9 @@ use futures::{
 };
 
 use spdk_sys::{
-    spdk_cpuset,
-
     spdk_event_allocate,
     spdk_event_call,
     spdk_set_thread,
-    spdk_thread_bind,
-    spdk_thread_create,
     spdk_thread_exit,
 };
 
@@ -33,8 +29,10 @@ use crate::{
     },
     task::{
         JoinHandle,
-        Task, ReactorTask,
+        ReactorTask,
+        Task,
     },
+    thread::Thread,
 };
 
 use super::{
@@ -71,36 +69,30 @@ impl Reactor {
         }
 
         // Spawn an asynchronous task to initialize the reactor.
-        let join_handle = self.spawn(async move {
-            unsafe {
-                // Create a new SPDK thread for this reactor and bind it to the
-                // reactor's core.
-                let name = CString::new(format!("reactor_thread_{}", self.core().id())).unwrap();
-                let cpu_mask: CpuSet = self.core().into();
+        let join_handle = self.spawn(move || async move {
+            // Create a new SPDK thread for this reactor and bind it to the
+            // reactor's core.
+            let name = CString::new(format!("reactor_thread_{}", self.core().id())).unwrap();
+            let cpu_mask: CpuSet = self.core().into();
 
-                let sthread = spdk_thread_create(
-                    name.as_ptr(),
-                    cpu_mask.as_ptr() as *mut spdk_cpuset);
+            let mut new_thread = Thread::new(&name, &cpu_mask).expect("thread created");
 
-                if sthread.is_null() {
-                    panic!("failed to create reactor thread on core {}", self.core().id());
+            new_thread.bind(true);
+
+            // Spawn an asynchronous task to wait for the reactor to exit.
+            let (exit_sx, exit_rx) = oneshot::channel::<()>();
+
+            spawn_local(async move {
+                let _ = exit_rx.await;
+
+                unsafe {
+                    spdk_set_thread(new_thread.as_mut_ptr());
+                    spdk_thread_exit(new_thread.as_mut_ptr());
                 }
+            });
 
-                spdk_thread_bind(sthread, true);
-
-                // Spawn an asynchronous task to wait for the reactor to exit.
-                let (exit_sx, exit_rx) = oneshot::channel::<()>();
-
-                self.spawn(async move {
-                    let _ = exit_rx.await;
-
-                    spdk_set_thread(sthread);
-                    spdk_thread_exit(sthread);
-                });
-
-                // Return the `Sender` used to signal the reactor to exit.
-                exit_sx
-            }
+            // Return the `Sender` used to signal the reactor to exit.
+            exit_sx
         });
 
         Some(join_handle)
@@ -180,11 +172,16 @@ impl Reactor {
 
     /// Spawns a new asynchronous task to be executed on this reactor and
     /// returns a [`JoinHandle`] to await results.
-    pub fn spawn<T>(&self, fut: impl Future<Output = T> + 'static) -> JoinHandle<T>
+    /// 
+    /// The indirection of `fut_gen` instead of receiving a `Future` directly
+    /// allows for futures that may not be `Send` once started.
+    pub fn spawn<G, F, T>(&self, fut_gen: G ) -> JoinHandle<T>
     where
-        T: 'static
+        G: FnOnce() -> F + Send + 'static,
+        F: Future<Output = T> + 'static,
+        T: Send + 'static
     {
-        let (task, join_handle) = ReactorTask::with_future(self.clone(), fut);
+        let (task, join_handle) = ReactorTask::with_future(self.clone(), fut_gen());
 
         Task::schedule(task);
 

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -38,7 +38,10 @@ use crate::{
 /// Kept --> Fulfilled : poll(cx)
 /// ```
 #[derive(Debug, Default)]
-enum PromiseState<T: Debug + Send + 'static> {
+enum PromiseState<T>
+where
+    T: Debug + 'static
+{
     /// The initial state of a promise.
     #[default]
     Empty,
@@ -74,9 +77,16 @@ enum PromiseState<T: Debug + Send + 'static> {
     Fulfilled,
 }
 
-unsafe impl<T: Debug + Send + 'static> Send for PromiseState<T> {}
+unsafe impl<T> Send for PromiseState<T>
+where
+    T: Debug + Send + 'static
+{
+}
 
-impl <T: Debug + Send + 'static> PromiseState<T> {
+impl <T> PromiseState<T>
+where
+    T: Debug + 'static
+{
     /// Returns a new `PromiseState` instance in the [`Empty`] state.
     /// 
     /// [`Empty`]: type@PromiseState::Empty
@@ -131,7 +141,7 @@ impl <T: Debug + Send + 'static> PromiseState<T> {
 /// null, the result is a suitable `Err(Errno)` value.
 pub unsafe extern "C" fn complete_with_object<T, R>(cx: *mut c_void, obj: *mut R)
 where
-    T: Debug + Send + TryFrom<*mut R, Error = Errno> + 'static,
+    T: Debug + TryFrom<*mut R, Error = Errno> + 'static,
 {
     let arc_self = Arc::from_raw(cx.cast::<Mutex<PromiseState<T>>>());
 
@@ -164,7 +174,7 @@ pub unsafe extern "C" fn complete_with_ok(cx: *mut c_void) {
 pub struct Promise<F, T>
 where
     F: FnMut(*mut c_void) -> Poll<Result<T, Errno>>,
-    T: Debug + Send + 'static
+    T: Debug + 'static
 {
     start_fn: F,
     state: Arc<Mutex<PromiseState<T>>>,
@@ -179,7 +189,7 @@ where
 impl<F, T> Promise<F, T>
 where
     F: FnMut(*mut c_void) -> Poll<Result<T, Errno>>,
-    T: Debug + Send + 'static
+    T: Debug + 'static
 {
     /// Returns a new `Promise` instance.
     /// 
@@ -197,7 +207,7 @@ where
 impl<F, T> Future for Promise<F, T>
 where
     F: FnMut(*mut c_void) -> Poll<Result<T, Errno>> + Unpin,
-    T: Debug + Send + 'static
+    T: Debug + 'static
 {
     type Output = Result<T, Errno>;
 


### PR DESCRIPTION
This PR allows !`Send` futures to be sent to other SPDK reactors and threads. It also remove `Send` and `Sync` markers for objects and traits which are not safe to send across threads or are used only in single threaded contexts.