### PR TITLE
feat: add user context to `Promise`

### DIFF
--- a/spdk/src/macros.rs
+++ b/spdk/src/macros.rs
@@ -46,6 +46,17 @@ macro_rules! to_poll_pending_on_ok {
             Err(e) => std::task::Poll::Ready(Err(e))
         }
     };
+    {$r:expr $(=> on ready $b:block)?} => {
+        {
+            let res = to_poll_pending_on_ok!($r);
+
+            $(if res.is_ready() {
+                $b;
+            })?
+
+            res
+        }
+    };
 }
 
 /// Convert an SPDK integer return value to a [`Poll`] value indicating whether
@@ -69,6 +80,17 @@ macro_rules! to_poll_pending_on_err {
             Ok(()) => std::task::Poll::Ready(Ok(())),
             Err(e) if e == $e => std::task::Poll::Pending,
             Err(e) => std::task::Poll::Ready(Err(e))
+        }
+    };
+    {$e:expr, $r:expr $(=> on ready $b:block)?} => {
+        {
+            let res = to_poll_pending_on_err!($e, $r);
+
+            $(if res.is_ready() {
+                $b;
+            })?
+
+            res
         }
     };
 }

--- a/spdk/src/task/mod.rs
+++ b/spdk/src/task/mod.rs
@@ -25,9 +25,6 @@ pub use poller::{
 };
 pub use promise::{
     Promise,
-
-    complete_with_object,
-    complete_with_status,
-    complete_with_ok,
+    Promissory,
 };
 pub use yield_now::yield_now;


### PR DESCRIPTION
Rewrites the `Promise` implementation and API to support a user supplied context and reduce the need for explicit casting.