### PR TITLE
chore: revamps task implementation to optimize spawning local tasks

### DIFF
--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.89"
 errno = "0.3.14"
 futures = "0.3.32"
 libc = "0.2.186"
+parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive"] }
 spdk-macros = { version = "0.1.0", path = "../spdk-macros" }
 spdk-sys = { version = "0.1.0", path = "../spdk-sys" }

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -94,10 +94,7 @@ impl EchoChannel {
         }
 
         // SAFETY: We will wait for the reader to consume the buffer before returning.
-        unsafe {
-            *src_buf =
-                Some(transmute::<&[std::io::IoSlice<'_>], &[std::io::IoSlice<'_>]>(io.buffers()))
-        };
+        unsafe { *src_buf = Some(transmute::<&[IoSlice<'_>], &[IoSlice<'_>]>(io.buffers())) };
 
         self.device.reader.notify_one();
 

--- a/spdk/src/runtime/reactor.rs
+++ b/spdk/src/runtime/reactor.rs
@@ -9,7 +9,7 @@ use spdk_sys::{spdk_event_allocate, spdk_event_call};
 
 use crate::{
     errors::{Errno, ENOMEM},
-    task::{JoinHandle, ReactorTask, Task},
+    task::{self, Executor, JoinHandle},
     thread::Thread,
 };
 
@@ -149,11 +149,20 @@ impl Reactor {
         F: Future<Output = T> + 'static,
         T: Send + 'static,
     {
-        let (task, join_handle) = ReactorTask::with_future(*self, fut_gen());
+        task::spawn_on_reactor(*self, fut_gen)
+    }
+}
 
-        Task::schedule(task);
+impl Executor for Reactor {
+    fn is_current(&self) -> bool {
+        self.is_current()
+    }
 
-        join_handle
+    fn schedule<F>(&self, f: F)
+    where
+        F: FnOnce() + 'static,
+    {
+        self.send_event(f).expect("send event");
     }
 }
 
@@ -164,11 +173,7 @@ where
     F: Future<Output = T> + 'static,
     T: 'static,
 {
-    let (task, join_handle) = ReactorTask::with_future(Reactor::current(), fut);
-
-    Task::schedule(task);
-
-    join_handle
+    task::spawn_on_current_reactor(fut)
 }
 
 /// An iterator over the reactors for this runtime.

--- a/spdk/src/runtime/reactor.rs
+++ b/spdk/src/runtime/reactor.rs
@@ -25,10 +25,9 @@ impl Reactor {
     ///
     /// # Returns
     ///
-    /// This function returns a [`JoinHandle<_>`] used to await a
-    /// [`Sender<()>`]. The `Sender` is used to signal the reactor to exit.
-    /// Since the main reactor cannot await itself, this function returns `None`
-    /// if called from the main CPU core.
+    /// This function returns a [`JoinHandle`] used to await a [`Sender<()>`]. The `Sender` is used
+    /// to signal the reactor to exit. Since the main reactor cannot await itself, this function
+    /// returns `None` if called from the main CPU core.
     ///
     /// # Panics
     ///

--- a/spdk/src/runtime/runtime.rs
+++ b/spdk/src/runtime/runtime.rs
@@ -18,7 +18,8 @@ use static_init::dynamic;
 use crate::{
     errors::{Errno, EINVAL},
     runtime::{reactors, Reactor},
-    task::{Task, ThreadTask},
+    task::{ArcTask, Task},
+    thread::Thread,
     to_result,
 };
 
@@ -211,18 +212,17 @@ impl Runtime {
         F: Future<Output = ()> + 'static,
         F::Output: 'static,
     {
-        let task = Arc::from_raw(ctx.cast::<ThreadTask<(), F>>());
+        let task = Arc::from_raw(ctx.cast::<Task<Thread, (), F>>());
 
-        Task::schedule_by_ref(&task);
+        ArcTask::schedule_by_ref(&task);
     }
 
     /// Starts the SPDK Application Framework with the given future.
     fn start<F>(&self, fut: F)
     where
         F: Future<Output = ()> + 'static,
-        F::Output: 'static,
     {
-        let (task, _) = ThreadTask::with_future(None, fut);
+        let (task, _) = Task::<Thread, (), F>::with_future(None, fut);
         let ctx = Arc::into_raw(task).cast_mut();
 
         unsafe {

--- a/spdk/src/runtime/runtime.rs
+++ b/spdk/src/runtime/runtime.rs
@@ -212,7 +212,7 @@ impl Runtime {
         F: Future<Output = ()> + 'static,
         F::Output: 'static,
     {
-        let task = Arc::from_raw(ctx.cast::<Task<Thread, (), F>>());
+        let task = Arc::from_raw(ctx.cast::<Task<Thread, F, ()>>());
 
         ArcTask::schedule_by_ref(&task);
     }
@@ -222,7 +222,7 @@ impl Runtime {
     where
         F: Future<Output = ()> + 'static,
     {
-        let (task, _) = Task::<Thread, (), F>::with_future(None, fut);
+        let (task, _) = Task::<Thread, F, ()>::with_future(None, fut);
         let ctx = Arc::into_raw(task).cast_mut();
 
         unsafe {

--- a/spdk/src/runtime/runtime.rs
+++ b/spdk/src/runtime/runtime.rs
@@ -6,7 +6,8 @@ use std::{
     mem::{size_of, MaybeUninit},
     os::raw::{c_char, c_int},
     ptr::{addr_of_mut, null},
-    sync::{atomic::AtomicBool, Arc},
+    rc::Rc,
+    sync::atomic::AtomicBool,
 };
 
 use spdk_sys::{
@@ -18,7 +19,7 @@ use static_init::dynamic;
 use crate::{
     errors::{Errno, EINVAL},
     runtime::{reactors, Reactor},
-    task::{ArcTask, Task},
+    task::{LocalTask, RcTask},
     thread::Thread,
     to_result,
 };
@@ -212,9 +213,9 @@ impl Runtime {
         F: Future<Output = ()> + 'static,
         F::Output: 'static,
     {
-        let task = Arc::from_raw(ctx.cast::<Task<Thread, F, ()>>());
+        let task = Rc::from_raw(ctx.cast::<LocalTask<Thread, F, ()>>());
 
-        ArcTask::schedule_by_ref(&task);
+        RcTask::schedule(task);
     }
 
     /// Starts the SPDK Application Framework with the given future.
@@ -222,8 +223,8 @@ impl Runtime {
     where
         F: Future<Output = ()> + 'static,
     {
-        let (task, _) = Task::<Thread, F, ()>::with_future(None, fut);
-        let ctx = Arc::into_raw(task).cast_mut();
+        let task = LocalTask::<Thread, F, ()>::with_future(fut);
+        let ctx = Rc::into_raw(task).cast_mut();
 
         unsafe {
             to_result!(spdk_app_start(

--- a/spdk/src/task/join_handle.rs
+++ b/spdk/src/task/join_handle.rs
@@ -1,43 +1,97 @@
 use std::{
-    pin::Pin,
+    future::Future,
     task::{Context, Poll},
 };
 
-use futures::{channel::oneshot, Future};
+/// A virtual function table (vtable) that specifies the operations that can be performed on a
+/// [`RawJoinHandle`].
+///
+/// The pointer passed to all functions in this vtable is the `data` pointer of the enclosing
+/// [`RawJoinHandle`] object. The vtable is used to construct a [`RawJoinHandle`] that is embedded
+/// in a [`JoinHandle`]. The vtable is used by `JoinHandle` orchestrate receiving the result of an
+/// asynchronous operation.
+pub(crate) struct RawJoinHandleVTable<T>
+where
+    T: 'static,
+{
+    poll_result: unsafe fn(*const (), &mut Context<'_>) -> Poll<T>,
+    drop: unsafe fn(*mut ()),
+}
+
+impl<T> RawJoinHandleVTable<T>
+where
+    T: 'static,
+{
+    /// Creates a new `RawJoinHandleVTable` with the specified `poll_result` and `drop` functions.
+    ///
+    /// `poll_result`
+    ///
+    /// This function is called when a [`JoinHandle`] is polled thorugh its [`Future`] trait
+    /// implementation. It returns a [`Poll<T>`] value indicating whether the task has completed
+    /// and, if so, the result of the task.
+    ///
+    /// `drop
+    ///
+    /// This function is called when a [`JoinHandle`] is dropped. It should perform any necessary
+    /// cleanup for the task.
+    pub(crate) const fn new(
+        poll_result: unsafe fn(*const (), &mut Context<'_>) -> Poll<T>,
+        drop: unsafe fn(*mut ()),
+    ) -> Self {
+        Self { poll_result, drop }
+    }
+}
+
+/// A raw handle to a task that can be used to await the result of the task.
+pub(crate) struct RawJoinHandle<T>
+where
+    T: 'static,
+{
+    vtable: &'static RawJoinHandleVTable<T>,
+    data: *mut (),
+}
 
 /// A handle that awaits the result of a task.
 ///
 /// Dropping a [`JoinHandle`] will detach the task leaving no way to join on
 /// it or obtain its result.
 ///
-/// A [`JoinHandle`] is created when task is spawned.
-pub struct JoinHandle<T> {
-    rx: oneshot::Receiver<T>,
+/// A [`JoinHandle`] is created when a task is spawned.
+pub struct JoinHandle<T>
+where
+    T: 'static,
+{
+    raw: RawJoinHandle<T>,
 }
 
-impl<T> JoinHandle<T> {
-    /// Create a new [`JoinHandle`] from a [`oneshot::Receiver`].
-    pub(crate) fn new(rx: oneshot::Receiver<T>) -> Self {
-        Self { rx }
-    }
-
-    /// Returns a pinned reference to the [`oneshot::Receiver`] used to receive
-    /// the result of the task.
-    pub(crate) fn rx_pin_mut(self: Pin<&mut Self>) -> Pin<&mut oneshot::Receiver<T>> {
-        unsafe { self.map_unchecked_mut(|s| &mut s.rx) }
+impl<T> JoinHandle<T>
+where
+    T: 'static,
+{
+    /// Creates a new `JoinHandle` with the specified `data` pointer and `vtable`.
+    pub(crate) const unsafe fn new(data: *mut (), vtable: &'static RawJoinHandleVTable<T>) -> Self {
+        Self {
+            raw: RawJoinHandle { vtable, data },
+        }
     }
 }
 
-impl<T> Future for JoinHandle<T> {
+impl<T> Future for JoinHandle<T>
+where
+    T: 'static,
+{
     type Output = T;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let pinned_rx = self.rx_pin_mut();
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        unsafe { (self.raw.vtable.poll_result)(self.raw.data, cx) }
+    }
+}
 
-        match pinned_rx.poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(r)) => Poll::Ready(r),
-            Poll::Ready(Err(_)) => panic!("sender dropped"),
-        }
+impl<T> Drop for JoinHandle<T>
+where
+    T: 'static,
+{
+    fn drop(&mut self) {
+        unsafe { (self.raw.vtable.drop)(self.raw.data) }
     }
 }

--- a/spdk/src/task/join_handle.rs
+++ b/spdk/src/task/join_handle.rs
@@ -1,6 +1,14 @@
 use std::{
     future::Future,
+    rc::Rc,
+    sync::Arc,
     task::{Context, Poll},
+};
+
+use crate::task::{
+    local_task,
+    remote_task::{self, ArcTask},
+    RcTask,
 };
 
 /// A virtual function table (vtable) that specifies the operations that can be performed on a
@@ -8,8 +16,8 @@ use std::{
 ///
 /// The pointer passed to all functions in this vtable is the `data` pointer of the enclosing
 /// [`RawJoinHandle`] object. The vtable is used to construct a [`RawJoinHandle`] that is embedded
-/// in a [`JoinHandle`]. The vtable is used by `JoinHandle` orchestrate receiving the result of an
-/// asynchronous operation.
+/// in a [`JoinHandle`]. The vtable is used by `JoinHandle` to orchestrate receiving the result of
+/// an asynchronous operation.
 pub(crate) struct RawJoinHandleVTable<T>
 where
     T: 'static,
@@ -26,11 +34,11 @@ where
     ///
     /// `poll_result`
     ///
-    /// This function is called when a [`JoinHandle`] is polled thorugh its [`Future`] trait
+    /// This function is called when a [`JoinHandle`] is polled through its [`Future`] trait
     /// implementation. It returns a [`Poll<T>`] value indicating whether the task has completed
     /// and, if so, the result of the task.
     ///
-    /// `drop
+    /// `drop`
     ///
     /// This function is called when a [`JoinHandle`] is dropped. It should perform any necessary
     /// cleanup for the task.
@@ -93,5 +101,31 @@ where
 {
     fn drop(&mut self) {
         unsafe { (self.raw.vtable.drop)(self.raw.data) }
+    }
+}
+
+impl<T, U> From<Rc<T>> for JoinHandle<U>
+where
+    T: RcTask<Output = U> + 'static,
+    U: 'static,
+{
+    fn from(rc: Rc<T>) -> Self {
+        let vtable = local_task::join_handle_vtable::<T>();
+        let data = Rc::into_raw(rc).cast_mut() as *mut _;
+
+        unsafe { Self::new(data, vtable) }
+    }
+}
+
+impl<T, U> From<Arc<T>> for JoinHandle<U>
+where
+    T: ArcTask<Output = U> + 'static,
+    U: Send + 'static,
+{
+    fn from(arc: Arc<T>) -> Self {
+        let vtable = remote_task::join_handle_vtable::<T>();
+        let data = Arc::into_raw(arc).cast_mut() as *mut _;
+
+        unsafe { Self::new(data, vtable) }
     }
 }

--- a/spdk/src/task/local_task.rs
+++ b/spdk/src/task/local_task.rs
@@ -1,0 +1,327 @@
+use std::{
+    any::TypeId,
+    cell::RefCell,
+    collections::HashMap,
+    future::Future,
+    mem::{self, ManuallyDrop},
+    pin::Pin,
+    rc::Rc,
+    sync::LazyLock,
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
+
+use futures::task::WakerRef;
+use parking_lot::RwLock;
+
+use crate::{
+    runtime::Reactor,
+    task::{Executor, JoinHandle, RawJoinHandleVTable, ResultState, TaskBase},
+    thread::Thread,
+};
+
+/// A way of scheduling and executing an asynchronous task on the current executor in the SPDK Event
+/// Framework.
+pub(crate) trait RcTask: TaskBase {
+    type Output: 'static;
+
+    /// Schedules a task for execution on its target, consuming the task in the process.
+    fn schedule(rc_self: Rc<Self>) {
+        let executor = rc_self.executor();
+
+        // If the current executor is the target of this task, attempt to run it synchronously.
+        if executor.is_current() && Self::run(&rc_self) {
+            return;
+        }
+
+        // The task could not be run synchronously, so enqueue it to run on the target executor at a
+        // later time.
+        executor.schedule(move || assert!(Self::run(&rc_self)));
+    }
+
+    /// Schedules a task for execution without consuming the task.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if this task's target executor is not the current executor.
+    fn schedule_by_ref(rc_self: &Rc<Self>) {
+        let executor = rc_self.executor();
+
+        assert!(executor.is_current());
+
+        // First, attempt to run the task synchronously.
+        if !Self::run(rc_self) {
+            // The task could not be run synchronously, so enqueue it to run on the target executor
+            // at a later time.
+            let cloned_task = rc_self.clone();
+
+            executor.schedule(move || assert!(Self::run(&cloned_task)));
+        }
+    }
+
+    /// Executes a task on the executor.
+    ///
+    /// # Returns
+    ///
+    /// This method returns `true` if the task was run synchronously. If it returns `false`, the
+    /// task could not be executed synchronously and should be scheduled to run later.
+    fn run(rc_self: &Rc<Self>) -> bool;
+
+    /// Polls the result of a task, returning `Poll::Pending` if the result is not yet ready, or
+    /// `Poll::Ready` with the result if it is ready.
+    fn poll_result(rc_self: &Rc<Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
+}
+
+/// Clones the [`RawWaker`] for this task.
+///
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_clone<W: RcTask>(data: *const ()) -> RawWaker {
+    Rc::<W>::increment_strong_count(data.cast());
+
+    RawWaker::new(data, waker_vtable::<W>())
+}
+
+/// Wakes the task referenced by the given [`RawWaker`] consuming the `RawWaker` in the process.
+///
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_wake<W: RcTask>(data: *const ()) {
+    let rc_task = Rc::<W>::from_raw(data.cast());
+
+    RcTask::schedule(rc_task);
+}
+
+/// Wakes the task referenced by the given [`RawWaker`] without consuming the `RawWaker`.
+///
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_wake_by_ref<W: RcTask>(data: *const ()) {
+    let rc_task = ManuallyDrop::new(Rc::<W>::from_raw(data.cast()));
+
+    RcTask::schedule_by_ref(&rc_task);
+}
+
+/// Drops the given [`RawWaker`] releasing its resources.
+///
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_drop<W: RcTask>(data: *const ()) {
+    drop(Rc::<W>::from_raw(data.cast()));
+}
+
+/// Gets the [`RawWakerVTable`] used by a [`RawWaker`] to awaken a task.
+const fn waker_vtable<W: RcTask>() -> &'static RawWakerVTable {
+    &RawWakerVTable::new(
+        waker_clone::<W>,
+        waker_wake::<W>,
+        waker_wake_by_ref::<W>,
+        waker_drop::<W>,
+    )
+}
+
+/// Creates a reference to the [`Waker`] from a reference to a [`LocalTask`].
+fn waker_ref<W: RcTask>(rc_self: &Rc<W>) -> WakerRef<'_> {
+    let data = Rc::as_ptr(rc_self).cast();
+
+    let waker =
+        ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(data, waker_vtable::<W>())) });
+
+    WakerRef::new_unowned(waker)
+}
+
+/// Polls a task for its result without consuming the task.
+///
+/// # Returns
+///
+/// `Poll::Pending` if the task has not yet completed, or `Poll::Ready(result)` if the task has
+/// completed and produced a result.
+unsafe fn join_handle_poll_result<J: RcTask>(
+    data: *const (),
+    cx: &mut Context<'_>,
+) -> Poll<J::Output> {
+    let rc_task = ManuallyDrop::new(Rc::<J>::from_raw(data.cast()));
+
+    RcTask::poll_result(&rc_task, cx)
+}
+
+/// Drops the task referenced by the given pointer, releasing its resources.
+unsafe fn join_handle_drop<J: RcTask>(data: *mut ()) {
+    drop(Rc::<J>::from_raw(data.cast()));
+}
+
+static JOIN_HANDLE_VTABLE_MAP: LazyLock<RwLock<HashMap<TypeId, Box<RawJoinHandleVTable<()>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Gets the [`RawJoinHandleVTable`] used by a [`JoinHandle`] to poll a task.
+pub(crate) fn join_handle_vtable<J: RcTask>() -> &'static RawJoinHandleVTable<J::Output> {
+    if let Some(vtable) = JOIN_HANDLE_VTABLE_MAP
+        .read()
+        .get(&TypeId::of::<J>())
+        .map(|v| unsafe {
+            &*(v as *const Box<RawJoinHandleVTable<()>>
+                as *const Box<RawJoinHandleVTable<J::Output>>)
+        })
+    {
+        return vtable.as_ref();
+    }
+
+    let vtable = unsafe {
+        &*(JOIN_HANDLE_VTABLE_MAP
+            .write()
+            .entry(TypeId::of::<J>())
+            .or_insert_with(|| {
+                mem::transmute(Box::new(RawJoinHandleVTable::new(
+                    join_handle_poll_result::<J>,
+                    join_handle_drop::<J>,
+                )))
+            }) as *const Box<RawJoinHandleVTable<()>>
+            as *const Box<RawJoinHandleVTable<J::Output>>)
+    };
+
+    vtable.as_ref()
+}
+
+/// Orchestrates the execution of a [`Future`] on the current [`Reactor`] or [`Thread`].
+pub(crate) struct LocalTask<E, F, T>
+where
+    E: Executor + 'static,
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    executor: Option<E>,
+    result: RefCell<ResultState<T>>,
+    future: RefCell<F>,
+}
+
+unsafe impl<E, F, T> Send for LocalTask<E, F, T>
+where
+    E: Executor + 'static,
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+}
+
+impl<F, T> LocalTask<Thread, F, T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    /// Constructs a new `LocalTask` from a [`Future`] to be scheduled on the current [`Thread`].
+    pub(crate) fn with_future(fut: F) -> Rc<Self> {
+        Rc::new(Self {
+            executor: Thread::try_current(),
+            result: RefCell::new(ResultState::Empty),
+            future: RefCell::new(fut),
+        })
+    }
+}
+
+impl<F, T> TaskBase for LocalTask<Thread, F, T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    fn executor(&self) -> impl Executor + 'static {
+        self.executor
+            .as_ref()
+            .map(Thread::borrow)
+            .unwrap_or_else(Thread::application)
+    }
+}
+
+impl<F, T> LocalTask<Reactor, F, T>
+where
+    T: 'static,
+    F: Future<Output = T> + 'static,
+{
+    /// Constructs a new `LocalTask` from a [`Future`] to be scheduled on the current [`Reactor`].
+    pub(crate) fn with_future(fut: F) -> Rc<Self> {
+        Rc::new(Self {
+            executor: Some(Reactor::current()),
+            result: RefCell::new(ResultState::Empty),
+            future: RefCell::new(fut),
+        })
+    }
+}
+
+impl<F, T> TaskBase for LocalTask<Reactor, F, T>
+where
+    T: 'static,
+    F: Future<Output = T> + 'static,
+{
+    fn executor(&self) -> impl Executor + 'static {
+        self.executor.unwrap()
+    }
+}
+
+impl<E, F, T> RcTask for LocalTask<E, F, T>
+where
+    E: Executor + 'static,
+    T: 'static,
+    F: Future<Output = T> + 'static,
+    LocalTask<E, F, T>: TaskBase,
+{
+    type Output = T;
+
+    fn run(rc_self: &Rc<Self>) -> bool {
+        match rc_self.future.try_borrow_mut() {
+            Ok(mut fut) => {
+                let waker = waker_ref(rc_self);
+                let mut ctx = Context::from_waker(&waker);
+
+                // SAFETY: The future is pinned in place for the duration of this function call, and
+                // it is not moved or dropped until the future is complete. The future is also not
+                // accessed from any other thread, so it is safe to create a pinned reference to it.
+                let fut = unsafe { Pin::new_unchecked(&mut *fut) };
+
+                match fut.poll(&mut ctx) {
+                    Poll::Ready(result) => {
+                        let res = rc_self.result.borrow_mut().set_result(result);
+
+                        if let Some(waker) = res {
+                            waker.wake();
+                        };
+                    }
+                    Poll::Pending => {}
+                }
+
+                true
+            }
+            // The task was re-entered while its future was already being polled. Return `false` to
+            // indicate that the task needs to be scheduled to run by its executor later.
+            Err(_) => false,
+        }
+    }
+
+    fn poll_result(rc_self: &Rc<Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        rc_self.result.borrow_mut().poll_result(cx)
+    }
+}
+
+/// Schedules a new asynchronous task to be executed on the current [`Thread`] and returns a
+/// [`JoinHandle`] to await results.
+pub(crate) fn spawn_on_current_thread<F, T>(fut: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    let task = LocalTask::<Thread, F, T>::with_future(fut);
+
+    RcTask::schedule_by_ref(&task);
+
+    task.into()
+}
+
+/// Schedules a new asynchronous task to be executed on the current [`Reactor`] and returns a
+/// [`JoinHandle`] to await results.
+pub(crate) fn spawn_on_current_reactor<F, T>(fut: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    let task = LocalTask::<Reactor, F, T>::with_future(fut);
+
+    RcTask::schedule_by_ref(&task);
+
+    task.into()
+}

--- a/spdk/src/task/mod.rs
+++ b/spdk/src/task/mod.rs
@@ -9,6 +9,7 @@ mod promise;
 mod task;
 mod yield_now;
 
+pub(crate) use join_handle::RawJoinHandleVTable;
 pub(crate) use task::{
     spawn_on_current_reactor, spawn_on_current_thread, spawn_on_reactor, spawn_on_thread, ArcTask,
     Executor, Task,

--- a/spdk/src/task/mod.rs
+++ b/spdk/src/task/mod.rs
@@ -9,7 +9,10 @@ mod promise;
 mod task;
 mod yield_now;
 
-pub(crate) use task::{ReactorTask, Task, ThreadTask};
+pub(crate) use task::{
+    spawn_on_current_reactor, spawn_on_current_thread, spawn_on_reactor, spawn_on_thread, ArcTask,
+    Executor, Task,
+};
 
 pub use join_handle::JoinHandle;
 pub use poller::{polled_fn, polled_fn_with_period, Polled, PolledFn, Poller};

--- a/spdk/src/task/mod.rs
+++ b/spdk/src/task/mod.rs
@@ -3,19 +3,91 @@
 //!
 //! [SPEF]: https://spdk.io/doc/event.html
 mod join_handle;
+mod local_task;
 mod poller;
 mod promise;
-#[allow(clippy::module_inception)]
-mod task;
+mod remote_task;
 mod yield_now;
 
-pub(crate) use join_handle::RawJoinHandleVTable;
-pub(crate) use task::{
-    spawn_on_current_reactor, spawn_on_current_thread, spawn_on_reactor, spawn_on_thread, ArcTask,
-    Executor, Task,
+use std::{
+    mem,
+    task::{Context, Poll, Waker},
 };
+
+pub(crate) use join_handle::RawJoinHandleVTable;
+pub(crate) use local_task::{spawn_on_current_reactor, spawn_on_current_thread, LocalTask, RcTask};
+pub(crate) use remote_task::{spawn_on_reactor, spawn_on_thread};
 
 pub use join_handle::JoinHandle;
 pub use poller::{polled_fn, polled_fn_with_period, Polled, PolledFn, Poller};
 pub use promise::{Promise, Promissory};
 pub use yield_now::yield_now;
+
+/// Represents the state of a task's result.
+#[derive(Default)]
+enum ResultState<T> {
+    /// The task has not yet completed and is waiting for the result to be produced.
+    #[default]
+    Empty,
+
+    /// The task has not yet completed, but a [`Waker`] has been registered to be notified when the
+    /// result is ready.
+    Waiting(Waker),
+
+    /// The task has completed and the result is ready to be consumed.
+    Ready(T),
+
+    /// The task has completed and the result has been consumed.
+    Consumed,
+}
+
+impl<T> ResultState<T> {
+    /// Sets the result of the task and wakes any registered [`Waker`].
+    fn set_result(&mut self, result: T) -> Option<Waker> {
+        match mem::replace(self, ResultState::Ready(result)) {
+            ResultState::Empty => None,
+            ResultState::Waiting(waker) => Some(waker),
+            ResultState::Ready(_) => panic!("result already set"),
+            ResultState::Consumed => panic!("result already consumed"),
+        }
+    }
+
+    /// Polls the result of the task, returning `Poll::Pending` if the result is not yet ready, or
+    /// `Poll::Ready` with the result if it is ready.
+    fn poll_result(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        match self {
+            ResultState::Empty => {
+                *self = ResultState::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            ResultState::Ready(_) => {
+                let res = mem::replace(self, ResultState::Consumed);
+
+                if let ResultState::Ready(res) = res {
+                    Poll::Ready(res)
+                } else {
+                    unreachable!()
+                }
+            }
+            ResultState::Waiting(_) => Poll::Pending,
+            ResultState::Consumed => panic!("poll_result called after result was consumed"),
+        }
+    }
+}
+
+/// A trait defining the interface for an executor that can schedule and execute tasks.
+pub(crate) trait Executor {
+    /// Returns `true` if the current executor is the same as this executor.
+    fn is_current(&self) -> bool;
+
+    /// Schedules a task for execution on this executor.
+    fn schedule<F>(&self, f: F)
+    where
+        F: FnOnce() + 'static;
+}
+
+/// A trait defining the base interface for a task.
+pub(crate) trait TaskBase: Send + 'static {
+    /// Returns the executor on which this task should be executed.
+    fn executor(&self) -> impl Executor + 'static;
+}

--- a/spdk/src/task/remote_task.rs
+++ b/spdk/src/task/remote_task.rs
@@ -14,81 +14,15 @@ use parking_lot::{Mutex, RwLock};
 
 use crate::{
     runtime::Reactor,
-    task::{JoinHandle, RawJoinHandleVTable},
+    task::{Executor, JoinHandle, RawJoinHandleVTable, ResultState, TaskBase},
     thread::Thread,
 };
 
-/// Represents the state of a task's result.
-#[derive(Default)]
-enum ResultState<T> {
-    /// The task has not yet completed and is waiting for the result to be produced.
-    #[default]
-    Empty,
-
-    /// The task has not yet completed, but a [`Waker`] has been registered to be notified when the
-    /// result is ready.
-    Waiting(Waker),
-
-    /// The task has completed and the result is ready to be consumed.
-    Ready(T),
-
-    /// The task has completed and the result has been consumed.
-    Consumed,
-}
-
-impl<T> ResultState<T> {
-    /// Sets the result of the task and wakes any registered [`Waker`].
-    fn set_result(&mut self, result: T) -> Option<Waker> {
-        match mem::replace(self, ResultState::Ready(result)) {
-            ResultState::Empty => None,
-            ResultState::Waiting(waker) => Some(waker),
-            ResultState::Ready(_) => panic!("result already set"),
-            ResultState::Consumed => panic!("result already consumed"),
-        }
-    }
-
-    /// Polls the result of the task, returning `Poll::Pending` if the result is not yet ready, or
-    /// `Poll::Ready` with the result if it is ready.
-    fn poll_result(&mut self, cx: &mut Context<'_>) -> Poll<T> {
-        match self {
-            ResultState::Empty => {
-                *self = ResultState::Waiting(cx.waker().clone());
-                Poll::Pending
-            }
-            ResultState::Ready(_) => {
-                let res = mem::replace(self, ResultState::Consumed);
-
-                if let ResultState::Ready(res) = res {
-                    Poll::Ready(res)
-                } else {
-                    unreachable!()
-                }
-            }
-            ResultState::Waiting(_) => Poll::Pending,
-            ResultState::Consumed => panic!("poll_result called after result was consumed"),
-        }
-    }
-}
-
-/// A trait defining the interface for an executor that can schedule and execute tasks.
-pub trait Executor {
-    /// Returns `true` if the current executor is the same as this executor.
-    fn is_current(&self) -> bool;
-
-    /// Schedules a task for execution on this executor.
-    fn schedule<F>(&self, f: F)
-    where
-        F: FnOnce() + 'static;
-}
-
-pub(crate) trait ArcTaskBase: Send + 'static {
-    /// Returns the executor on which this task should be executed.
-    fn executor(&self) -> impl Executor + 'static;
-}
-
-/// A way of scheduling and executing an asynchronous task in the SPDK Event Framework.
-pub(crate) trait ArcTask: ArcTaskBase {
-    type Output: 'static;
+/// A way of scheduling and executing an asynchronous task on a different executor in the SPDK Event
+/// Framework.
+pub(crate) trait ArcTask: TaskBase {
+    /// The type of value produced by the task when it completes.
+    type Output: Send + 'static;
 
     /// Schedules a task for execution on its target, consuming the task in the process.
     fn schedule(arc_self: Arc<Self>) {
@@ -105,23 +39,19 @@ pub(crate) trait ArcTask: ArcTaskBase {
     }
 
     /// Schedules a task for execution without consuming the task.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if this task's target executor is not the current executor.
     fn schedule_by_ref(arc_self: &Arc<Self>) {
         let executor = arc_self.executor();
 
-        assert!(executor.is_current());
-
-        // First, attempt to run the task synchronously.
-        if !Self::run(arc_self) {
-            // The task could not be run synchronously, so enqueue it to run on the target executor
-            // at a later time.
-            let cloned_task = arc_self.clone();
-
-            executor.schedule(move || assert!(Self::run(&cloned_task)));
+        // If the current executor is the target of this task, attempt to run it synchronously.
+        if executor.is_current() && Self::run(arc_self) {
+            return;
         }
+
+        // The task could not be run synchronously, so enqueue it to run on the target executor
+        // at a later time.
+        let cloned_task = arc_self.clone();
+
+        executor.schedule(move || assert!(Self::run(&cloned_task)));
     }
 
     /// Executes a task on the executor.
@@ -185,7 +115,7 @@ const fn waker_vtable<W: ArcTask>() -> &'static RawWakerVTable {
     )
 }
 
-/// Creates a reference to the [`Waker`] from a reference to a [`Task<T>`].
+/// Creates a reference to the [`Waker`] from a reference to a [`RemoteTask`].
 fn waker_ref<W: ArcTask>(arc_self: &Arc<W>) -> WakerRef<'_> {
     let data = Arc::as_ptr(arc_self).cast();
 
@@ -199,7 +129,7 @@ fn waker_ref<W: ArcTask>(arc_self: &Arc<W>) -> WakerRef<'_> {
 ///
 /// # Returns
 ///
-/// Poll::Pending` if the task has not yet completed, or `Poll::Ready(result)` if the task has
+/// `Poll::Pending` if the task has not yet completed, or `Poll::Ready(result)` if the task has
 /// completed and produced a result.
 unsafe fn join_handle_poll_result<J: ArcTask>(
     data: *const (),
@@ -219,7 +149,7 @@ static JOIN_HANDLE_VTABLE_MAP: LazyLock<RwLock<HashMap<TypeId, Box<RawJoinHandle
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Gets the [`RawJoinHandleVTable`] used by a [`JoinHandle`] to poll a task.
-fn join_handle_vtable<J: ArcTask>() -> &'static RawJoinHandleVTable<J::Output> {
+pub(crate) fn join_handle_vtable<J: ArcTask>() -> &'static RawJoinHandleVTable<J::Output> {
     if let Some(vtable) = JOIN_HANDLE_VTABLE_MAP
         .read()
         .get(&TypeId::of::<J>())
@@ -247,62 +177,45 @@ fn join_handle_vtable<J: ArcTask>() -> &'static RawJoinHandleVTable<J::Output> {
     vtable.as_ref()
 }
 
-/// Orchestrates the execution of a [`Future`].
-pub(crate) struct Task<E, F, T>
+/// Orchestrates the execution of a [`Future`] on another [`Reactor`] or [`Thread`].
+pub(crate) struct RemoteTask<E, F, T>
 where
     E: Executor + 'static,
     F: Future<Output = T> + 'static,
-    T: 'static,
+    T: Send + 'static,
 {
     executor: Option<E>,
     result: Mutex<ResultState<T>>,
     future: RefCell<F>,
 }
 
-unsafe impl<E, F, T> Send for Task<E, F, T>
+unsafe impl<E, F, T> Send for RemoteTask<E, F, T>
 where
     E: Executor + 'static,
     F: Future<Output = T> + 'static,
-    T: 'static,
+    T: Send + 'static,
 {
 }
 
-impl<F, T> Task<Thread, F, T>
+impl<F, T> RemoteTask<Thread, F, T>
 where
     F: Future<Output = T> + 'static,
-    T: 'static,
+    T: Send + 'static,
 {
-    /// Constructs a new task from a [`Future`] to be scheduled on a [`Thread`].
-    ///
-    /// If `executor` is `None`, the task will be scheduled to run on the application thread.
-    ///
-    /// # Return
-    ///
-    /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
-    /// used to await the result of executing the `Future`.
-    pub(crate) fn with_future(executor: Option<Thread>, fut: F) -> (Arc<Self>, JoinHandle<T>) {
-        let task = Arc::new(Self {
+    /// Constructs a new `RemoteTask` from a [`Future`] to be scheduled on the specified [`Thread`].
+    pub(crate) fn with_future(executor: Option<Thread>, fut: F) -> Arc<Self> {
+        Arc::new(Self {
             executor,
             result: Mutex::new(ResultState::Empty),
             future: RefCell::new(fut),
-        });
-
-        let cloned_task = task.clone();
-        let join_handle = unsafe {
-            JoinHandle::new(
-                Arc::into_raw(cloned_task) as *mut _,
-                join_handle_vtable::<Self>(),
-            )
-        };
-
-        (task, join_handle)
+        })
     }
 }
 
-impl<F, T> ArcTaskBase for Task<Thread, F, T>
+impl<F, T> TaskBase for RemoteTask<Thread, F, T>
 where
     F: Future<Output = T> + 'static,
-    T: 'static,
+    T: Send + 'static,
 {
     fn executor(&self) -> impl Executor + 'static {
         self.executor
@@ -312,39 +225,24 @@ where
     }
 }
 
-impl<F, T> Task<Reactor, F, T>
+impl<F, T> RemoteTask<Reactor, F, T>
 where
-    T: 'static,
+    T: Send + 'static,
     F: Future<Output = T> + 'static,
 {
-    /// Constructs a new task from a [`Future`] to be scheduled on the given [`Reactor`]
-    ///
-    /// # Return
-    ///
-    /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
-    /// used to await the result of executing the `Future`.
-    pub(crate) fn with_future(executor: Reactor, fut: F) -> (Arc<Self>, JoinHandle<T>) {
-        let task = Arc::new(Self {
+    /// Constructs a new `RemoteTask` from a [`Future`] to be scheduled on the specified [`Reactor`].
+    pub(crate) fn with_future(executor: Reactor, fut: F) -> Arc<Self> {
+        Arc::new(Self {
             executor: Some(executor),
             result: Mutex::new(ResultState::Empty),
             future: RefCell::new(fut),
-        });
-
-        let cloned_task = task.clone();
-        let join_handle = unsafe {
-            JoinHandle::new(
-                Arc::into_raw(cloned_task) as *mut _,
-                join_handle_vtable::<Self>(),
-            )
-        };
-
-        (task, join_handle)
+        })
     }
 }
 
-impl<F, T> ArcTaskBase for Task<Reactor, F, T>
+impl<F, T> TaskBase for RemoteTask<Reactor, F, T>
 where
-    T: 'static,
+    T: Send + 'static,
     F: Future<Output = T> + 'static,
 {
     fn executor(&self) -> impl Executor + 'static {
@@ -352,12 +250,12 @@ where
     }
 }
 
-impl<E, F, T> ArcTask for Task<E, F, T>
+impl<E, F, T> ArcTask for RemoteTask<E, F, T>
 where
     E: Executor + 'static,
-    T: 'static,
+    T: Send + 'static,
     F: Future<Output = T> + 'static,
-    Task<E, F, T>: ArcTaskBase,
+    RemoteTask<E, F, T>: TaskBase,
 {
     type Output = T;
 
@@ -407,25 +305,11 @@ where
     F: Future<Output = T> + 'static,
     T: Send + 'static,
 {
-    let (task, join_handle) = Task::<Thread, F, T>::with_future(Some(thread), fut_gen());
+    let task = RemoteTask::<Thread, F, T>::with_future(Some(thread), fut_gen());
 
-    ArcTask::schedule(task);
+    ArcTask::schedule_by_ref(&task);
 
-    join_handle
-}
-
-/// Schedules a new asynchronous task to be executed on the current [`Thread`] and returns a
-/// [`JoinHandle`] to await results.
-pub(crate) fn spawn_on_current_thread<F, T>(fut: F) -> JoinHandle<T>
-where
-    F: Future<Output = T> + 'static,
-    T: 'static,
-{
-    let (task, join_handle) = Task::<Thread, F, T>::with_future(Thread::try_current(), fut);
-
-    ArcTask::schedule(task);
-
-    join_handle
+    task.into()
 }
 
 /// Schedules a new asynchronous task to be executed on the given [`Reactor`] and returns a
@@ -439,23 +323,9 @@ where
     F: Future<Output = T> + 'static,
     T: Send + 'static,
 {
-    let (task, join_handle) = Task::<Reactor, F, T>::with_future(reactor, fut_gen());
+    let task = RemoteTask::<Reactor, F, T>::with_future(reactor, fut_gen());
 
-    ArcTask::schedule(task);
+    ArcTask::schedule_by_ref(&task);
 
-    join_handle
-}
-
-/// Schedules a new asynchronous task to be executed on the current [`Reactor`] and returns a
-/// [`JoinHandle`] to await results.
-pub(crate) fn spawn_on_current_reactor<F, T>(fut: F) -> JoinHandle<T>
-where
-    F: Future<Output = T> + 'static,
-    T: 'static,
-{
-    let (task, join_handle) = Task::<Reactor, F, T>::with_future(Reactor::current(), fut);
-
-    ArcTask::schedule(task);
-
-    join_handle
+    task.into()
 }

--- a/spdk/src/task/task.rs
+++ b/spdk/src/task/task.rs
@@ -14,64 +14,107 @@ use crate::{runtime::Reactor, thread::Thread};
 
 use super::JoinHandle;
 
-/// A way of scheduling and executing an asynchronous task in the SPDK Event
-/// Framework.
-pub(crate) trait Task: Send {
-    /// Schedules a task for execution on its target, consuming the task in the
-    /// process.
-    fn schedule(arc_self: Arc<Self>);
+/// A trait defining the interface for an executor that can schedule and execute tasks.
+pub(crate) trait Executor {
+    /// Returns `true` if the current executor is the same as this executor.
+    fn is_current(&self) -> bool;
+
+    /// Schedules a task for execution on this executor.
+    fn schedule<F>(&self, f: F)
+    where
+        F: FnOnce() + 'static;
+}
+
+pub(crate) trait ArcTaskBase: Send + 'static {
+    /// Returns the executor on which this task should be executed.
+    fn executor(&self) -> impl Executor + 'static;
+}
+
+/// A way of scheduling and executing an asynchronous task in the SPDK Event Framework.
+pub(crate) trait ArcTask: ArcTaskBase {
+    /// Schedules a task for execution on its target, consuming the task in the process.
+    fn schedule(arc_self: Arc<Self>) {
+        let executor = arc_self.executor();
+
+        // If the current executor is the target of this task, attempt to run it synchronously.
+        if executor.is_current() && Self::run(&arc_self) {
+            return;
+        }
+
+        // The task could not be run synchronously, so enqueue it to run on the target executor at a
+        // later time.
+        executor.schedule(move || assert!(Self::run(&arc_self)));
+    }
 
     /// Schedules a task for execution without consuming the task.
     ///
     /// # Panics
     ///
-    /// This method panics if this task's target executor is not the current
-    /// executor.
-    fn schedule_by_ref(arc_self: &Arc<Self>);
+    /// This method panics if this task's target executor is not the current executor.
+    fn schedule_by_ref(arc_self: &Arc<Self>) {
+        let executor = arc_self.executor();
+
+        assert!(executor.is_current());
+
+        // First, attempt to run the task synchronously.
+        if !Self::run(arc_self) {
+            // The task could not be run synchronously, so enqueue it to run on the target executor
+            // at a later time.
+            let cloned_task = arc_self.clone();
+
+            executor.schedule(move || assert!(Self::run(&cloned_task)));
+        }
+    }
+
+    /// Executes a task on the executor.
+    ///
+    /// # Returns
+    ///
+    /// This method returns `true` if the task was run synchronously. If it returns `false`, the
+    /// task could not be executed synchronously and should be scheduled to run later.
+    fn run(arc_self: &Arc<Self>) -> bool;
 }
 
 /// Clones the [`RawWaker`] for this task.
 ///
-/// This function is invoked through the [`RawWakerVTable`] created by the
-/// [`waker_ref<W>`] function.
-unsafe fn waker_clone<W: Task>(data: *const ()) -> RawWaker {
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_clone<W: ArcTask>(data: *const ()) -> RawWaker {
     Arc::<W>::increment_strong_count(data.cast());
 
     RawWaker::new(data, waker_vtable::<W>())
 }
 
-/// Wakes the task referenced by the given [`RawWaker`] consuming the `RawWaker`
-/// in the process.
+/// Wakes the task referenced by the given [`RawWaker`] consuming the `RawWaker` in the process.
 ///
-/// This function is invoked through the [`RawWakerVTable`] created by the
-/// [`waker_ref<W>`] function.
-unsafe fn waker_wake<W: Task>(data: *const ()) {
-    let rc_task = Arc::<W>::from_raw(data.cast());
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_wake<W: ArcTask>(data: *const ()) {
+    let arc_task = Arc::<W>::from_raw(data.cast());
 
-    Task::schedule(rc_task);
+    ArcTask::schedule(arc_task);
 }
 
-/// Wakes the task referenced by the given [`RawWaker`] without consuming the
-/// `RawWaker`.
+/// Wakes the task referenced by the given [`RawWaker`] without consuming the `RawWaker`.
 ///
-/// This function is invoked through the [`RawWakerVTable`] created by the
-/// [`waker_ref<W>`] function.
-unsafe fn waker_wake_by_ref<W: Task>(data: *const ()) {
-    let rc_task = ManuallyDrop::new(Arc::<W>::from_raw(data.cast()));
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_wake_by_ref<W: ArcTask>(data: *const ()) {
+    let arc_task = ManuallyDrop::new(Arc::<W>::from_raw(data.cast()));
 
-    Task::schedule_by_ref(&rc_task);
+    ArcTask::schedule_by_ref(&arc_task);
 }
 
 /// Drops the given [`RawWaker`] releasing its resources.
 ///
-/// This function is invoked through the [`RawWakerVTable`] created by the
-/// [`waker_ref<W>`] function.
-unsafe fn waker_drop<W: Task>(data: *const ()) {
+/// This function is invoked through the [`RawWakerVTable`] created by the [`waker_ref<W>`]
+/// function.
+unsafe fn waker_drop<W: ArcTask>(data: *const ()) {
     drop(Arc::<W>::from_raw(data.cast()));
 }
 
 /// Gets the [`RawWakerVTable`] used by a [`RawWaker`] to awaken a task.
-fn waker_vtable<W: Task>() -> &'static RawWakerVTable {
+fn waker_vtable<W: ArcTask>() -> &'static RawWakerVTable {
     &RawWakerVTable::new(
         waker_clone::<W>,
         waker_wake::<W>,
@@ -81,7 +124,7 @@ fn waker_vtable<W: Task>() -> &'static RawWakerVTable {
 }
 
 /// Creates a reference to the [`Waker`] from a reference to a [`Task<T>`].
-fn waker_ref<W: Task>(arc_self: &Arc<W>) -> WakerRef<'_> {
+fn waker_ref<W: ArcTask>(arc_self: &Arc<W>) -> WakerRef<'_> {
     let data = Arc::as_ptr(arc_self).cast();
 
     let waker =
@@ -145,8 +188,7 @@ impl TaskState {
     ///
     /// # Panics
     ///
-    /// This method panics if the task is polled in a state other than `Pending`
-    /// or `Polling`.
+    /// This method panics if the task is polled in a state other than `Pending` or `Polling`.
     fn poll(&mut self) -> Self {
         match self {
             Self::Pending => self.replace(Self::Polling),
@@ -157,43 +199,43 @@ impl TaskState {
 }
 
 /// Orchestrates the execution of a [`Future`].
-pub(crate) struct ThreadTask<T, F>
+pub(crate) struct Task<E, T, F>
 where
+    E: Executor + 'static,
     T: 'static,
     F: Future<Output = T> + 'static,
 {
-    target_thread: Option<Thread>,
+    executor: Option<E>,
     state: RefCell<TaskState>,
     result_sender: UnsafeCell<Option<oneshot::Sender<T>>>,
     future: UnsafeCell<F>,
 }
 
-unsafe impl<T, F> Send for ThreadTask<T, F>
+unsafe impl<E, T, F> Send for Task<E, T, F>
 where
+    E: Executor + 'static,
     T: 'static,
     F: Future<Output = T> + 'static,
 {
 }
 
-impl<T, F> ThreadTask<T, F>
+impl<T, F> Task<Thread, T, F>
 where
     T: 'static,
     F: Future<Output = T> + 'static,
 {
     /// Constructs a new task from a [`Future`] to be scheduled on a [`Thread`].
     ///
-    /// If `target_thread` is `None`, the task will be scheduled to run on the
-    /// application thread.
+    /// If `executor` is `None`, the task will be scheduled to run on the application thread.
     ///
     /// # Return
     ///
-    /// This function returns both a newly constructed [`ThreadTask`] and a
-    /// [`JoinHandle`] that can be used to await the result of executing the
-    /// [`Future`].
-    pub(crate) fn with_future(target_thread: Option<Thread>, fut: F) -> (Arc<Self>, JoinHandle<T>) {
+    /// This function returns both a newly constructed [`ThreadTask`] and a [`JoinHandle`] that can
+    /// be used to await the result of executing the [`Future`].
+    pub(crate) fn with_future(executor: Option<Thread>, fut: F) -> (Arc<Self>, JoinHandle<T>) {
         let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
-            target_thread,
+            executor,
             state: RefCell::new(TaskState::Pending),
             result_sender: UnsafeCell::new(Some(sx)),
             future: UnsafeCell::new(fut),
@@ -201,131 +243,36 @@ where
 
         (task, JoinHandle::new(rx))
     }
+}
 
-    /// Returns the target [`Thread`] of this task.
-    fn target_thread(&self) -> Thread {
-        self.target_thread
+impl<T, F> ArcTaskBase for Task<Thread, T, F>
+where
+    T: 'static,
+    F: Future<Output = T> + 'static,
+{
+    fn executor(&self) -> impl Executor + 'static {
+        self.executor
             .as_ref()
             .map(Thread::borrow)
             .unwrap_or_else(Thread::application)
     }
-
-    /// Executes a task on the executor.
-    ///
-    /// # Returns
-    ///
-    /// This method returns `true` if the task was run synchronously. If it
-    /// returns `false`, the task could not be executed synchronously and
-    /// should be scheduled to run later.
-    fn run(arc_self: &Arc<Self>) -> bool {
-        let state = arc_self.state.borrow_mut().poll();
-
-        match state {
-            TaskState::Pending => {
-                let waker = waker_ref(arc_self);
-                let ctx = &mut Context::from_waker(&waker);
-
-                // SAFETY: The future is only polled when in the `Polling` state
-                // (i.e. previous state was `Pending`). There are no other
-                // references to it.
-                let mut fut = unsafe { Pin::new_unchecked(&mut *arc_self.future.get()) };
-
-                match fut.as_mut().poll(ctx) {
-                    Poll::Pending => arc_self.state.borrow_mut().mark_pending(),
-                    Poll::Ready(r) => {
-                        // SAFETY: The result sender is only taken when in the
-                        // `Done` state. There are no other references to it.
-                        let _ = unsafe { &mut *arc_self.result_sender.get() }
-                            .take()
-                            .unwrap()
-                            .send(r);
-                        arc_self.state.borrow_mut().mark_done();
-                    }
-                }
-
-                true
-            }
-            TaskState::Polling => false,
-            _ => unreachable!(),
-        }
-    }
 }
 
-impl<T, F> Task for ThreadTask<T, F>
+impl<T, F> Task<Reactor, T, F>
 where
     T: 'static,
     F: Future<Output = T> + 'static,
 {
-    fn schedule(arc_self: Arc<Self>) {
-        let target_thread = arc_self.target_thread();
-
-        // If the current thread is the target of this task, attempt to run it
-        // synchronously.
-        if target_thread.is_current() && Self::run(&arc_self) {
-            return;
-        }
-
-        // The task could not be run synchronously, so enqueue it to run on the
-        // this thread at a later time.
-        target_thread
-            .send_msg(move || assert!(Self::run(&arc_self)))
-            .unwrap();
-    }
-
-    fn schedule_by_ref(arc_self: &Arc<Self>) {
-        let target_thread = arc_self.target_thread();
-
-        assert!(target_thread.is_current());
-
-        // First, attempt to run the task synchronously.
-        if !Self::run(arc_self) {
-            // The task could not be run synchronously, so enqueue it to run on the
-            // this thread at a later time.
-            let cloned_task = arc_self.clone();
-
-            target_thread
-                .send_msg(move || assert!(Self::run(&cloned_task)))
-                .unwrap();
-        }
-    }
-}
-
-/// Orchestrates the execution of a [`Future`] on a reactor.
-pub(crate) struct ReactorTask<T, F>
-where
-    T: 'static,
-    F: Future<Output = T> + 'static,
-{
-    target_reactor: Reactor,
-    state: RefCell<TaskState>,
-    result_sender: UnsafeCell<Option<oneshot::Sender<T>>>,
-    future: UnsafeCell<F>,
-}
-
-unsafe impl<T, F> Send for ReactorTask<T, F>
-where
-    T: 'static,
-    F: Future<Output = T> + 'static,
-{
-}
-
-impl<T, F> ReactorTask<T, F>
-where
-    T: 'static,
-    F: Future<Output = T> + 'static,
-{
-    /// Constructs a new task from a [`Future`] to be scheduled on the given
-    /// [`Reactor`]
+    /// Constructs a new task from a [`Future`] to be scheduled on the given [`Reactor`]
     ///
     /// # Return
     ///
-    /// This function returns both a newly constructed [`ReactorTask`] and a
-    /// [`JoinHandle`] that can be used to await the result of executing the
-    /// [`Future`].
-    pub(crate) fn with_future(target_reactor: Reactor, fut: F) -> (Arc<Self>, JoinHandle<T>) {
+    /// This function returns both a newly constructed [`ReactorTask`] and a [`JoinHandle`] that can
+    /// be used to await the result of executing the [`Future`].
+    pub(crate) fn with_future(executor: Reactor, fut: F) -> (Arc<Self>, JoinHandle<T>) {
         let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
-            target_reactor,
+            executor: Some(executor),
             state: RefCell::new(TaskState::Pending),
             result_sender: UnsafeCell::new(Some(sx)),
             future: UnsafeCell::new(fut),
@@ -333,14 +280,25 @@ where
 
         (task, JoinHandle::new(rx))
     }
+}
 
-    /// Executes a task on the executor.
-    ///
-    /// # Returns
-    ///
-    /// This method returns `true` if the task was run synchronously. If it
-    /// returns `false`, the task could not be executed synchronously and
-    /// should be scheduled to run later.
+impl<T, F> ArcTaskBase for Task<Reactor, T, F>
+where
+    T: 'static,
+    F: Future<Output = T> + 'static,
+{
+    fn executor(&self) -> impl Executor + 'static {
+        self.executor.unwrap()
+    }
+}
+
+impl<E, T, F> ArcTask for Task<E, T, F>
+where
+    E: Executor + 'static,
+    T: 'static,
+    F: Future<Output = T> + 'static,
+    Task<E, T, F>: ArcTaskBase,
+{
     fn run(arc_self: &Arc<Self>) -> bool {
         let state = arc_self.state.borrow_mut().poll();
 
@@ -349,16 +307,15 @@ where
                 let waker = waker_ref(arc_self);
                 let ctx = &mut Context::from_waker(&waker);
 
-                // SAFETY: The future is only polled when in the `Polling` state
-                // (i.e. previous state was `Pending`). There are no other
-                // references to it.
+                // SAFETY: The future is only polled when in the `Polling` state (i.e. previous
+                // state was `Pending`). There are no other references to it.
                 let mut fut = unsafe { Pin::new_unchecked(&mut *arc_self.future.get()) };
 
                 match fut.as_mut().poll(ctx) {
                     Poll::Pending => arc_self.state.borrow_mut().mark_pending(),
                     Poll::Ready(r) => {
-                        // SAFETY: The result sender is only taken when in the
-                        // `Done` state. There are no other references to it.
+                        // SAFETY: The result sender is only taken when in the `Done` state. There
+                        // are no other references to it.
                         let _ = unsafe { &mut *arc_self.result_sender.get() }
                             .take()
                             .unwrap()
@@ -375,41 +332,66 @@ where
     }
 }
 
-impl<T, F> Task for ReactorTask<T, F>
+/// Schedules a new asynchronous task to be executed on the given [`Thread`] and returns a
+/// [`JoinHandle`] to await results.
+///
+/// The indirection of `fut_gen` instead of receiving a `Future` directly allows for futures that
+/// may not be `Send` once started.
+pub(crate) fn spawn_on_thread<G, F, T>(thread: Thread, fut_gen: G) -> JoinHandle<T>
 where
-    T: 'static,
+    G: FnOnce() -> F + Send + 'static,
     F: Future<Output = T> + 'static,
+    T: Send + 'static,
 {
-    fn schedule(arc_self: Arc<Self>) {
-        let target_reactor = arc_self.target_reactor;
+    let (task, join_handle) = Task::<Thread, T, F>::with_future(Some(thread), fut_gen());
 
-        // If the current reactor is the target of this task, attempt to run it
-        // synchronously.
-        if target_reactor.is_current() && Self::run(&arc_self) {
-            return;
-        }
+    ArcTask::schedule(task);
 
-        // The task could not be run synchronously, so enqueue it to run on the
-        // this reactor at a later time.
-        target_reactor
-            .send_event(move || assert!(Self::run(&arc_self)))
-            .unwrap();
-    }
+    join_handle
+}
 
-    fn schedule_by_ref(arc_self: &Arc<Self>) {
-        let target_reactor = arc_self.target_reactor;
+/// Schedules a new asynchronous task to be executed on the current [`Thread`] and returns a
+/// [`JoinHandle`] to await results.
+pub(crate) fn spawn_on_current_thread<F, T>(fut: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    let (task, join_handle) = Task::<Thread, T, F>::with_future(Thread::try_current(), fut);
 
-        assert!(target_reactor.is_current());
+    ArcTask::schedule(task);
 
-        // First, attempt to run the task synchronously.
-        if !Self::run(arc_self) {
-            // The task could not be run synchronously, so enqueue it to run on
-            // the this reactor at a later time.
-            let cloned_task = arc_self.clone();
+    join_handle
+}
 
-            target_reactor
-                .send_event(move || assert!(Self::run(&cloned_task)))
-                .unwrap();
-        }
-    }
+/// Schedules a new asynchronous task to be executed on the given [`Reactor`] and returns a
+/// [`JoinHandle`] to await results.
+///
+/// The indirection of `fut_gen` instead of receiving a `Future` directly allows for futures that
+/// may not be `Send` once started.
+pub(crate) fn spawn_on_reactor<G, F, T>(reactor: Reactor, fut_gen: G) -> JoinHandle<T>
+where
+    G: FnOnce() -> F + Send + 'static,
+    F: Future<Output = T> + 'static,
+    T: Send + 'static,
+{
+    let (task, join_handle) = Task::<Reactor, T, F>::with_future(reactor, fut_gen());
+
+    ArcTask::schedule(task);
+
+    join_handle
+}
+
+/// Schedules a new asynchronous task to be executed on the current [`Reactor`] and returns a
+/// [`JoinHandle`] to await results.
+pub(crate) fn spawn_on_current_reactor<F, T>(fut: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    let (task, join_handle) = Task::<Reactor, T, F>::with_future(Reactor::current(), fut);
+
+    ArcTask::schedule(task);
+
+    join_handle
 }

--- a/spdk/src/task/task.rs
+++ b/spdk/src/task/task.rs
@@ -1,20 +1,77 @@
 use std::{
-    cell::{RefCell, UnsafeCell},
+    any::TypeId,
+    cell::RefCell,
+    collections::HashMap,
     future::Future,
-    mem::ManuallyDrop,
+    mem::{self, ManuallyDrop},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
 
-use futures::{channel::oneshot, task::WakerRef};
+use futures::task::WakerRef;
+use parking_lot::{Mutex, RwLock};
 
-use crate::{runtime::Reactor, thread::Thread};
+use crate::{
+    runtime::Reactor,
+    task::{JoinHandle, RawJoinHandleVTable},
+    thread::Thread,
+};
 
-use super::JoinHandle;
+/// Represents the state of a task's result.
+#[derive(Default)]
+enum ResultState<T> {
+    /// The task has not yet completed and is waiting for the result to be produced.
+    #[default]
+    Empty,
+
+    /// The task has not yet completed, but a [`Waker`] has been registered to be notified when the
+    /// result is ready.
+    Waiting(Waker),
+
+    /// The task has completed and the result is ready to be consumed.
+    Ready(T),
+
+    /// The task has completed and the result has been consumed.
+    Consumed,
+}
+
+impl<T> ResultState<T> {
+    /// Sets the result of the task and wakes any registered [`Waker`].
+    fn set_result(&mut self, result: T) -> Option<Waker> {
+        match mem::replace(self, ResultState::Ready(result)) {
+            ResultState::Empty => None,
+            ResultState::Waiting(waker) => Some(waker),
+            ResultState::Ready(_) => panic!("result already set"),
+            ResultState::Consumed => panic!("result already consumed"),
+        }
+    }
+
+    /// Polls the result of the task, returning `Poll::Pending` if the result is not yet ready, or
+    /// `Poll::Ready` with the result if it is ready.
+    fn poll_result(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        match self {
+            ResultState::Empty => {
+                *self = ResultState::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            ResultState::Ready(_) => {
+                let res = mem::replace(self, ResultState::Consumed);
+
+                if let ResultState::Ready(res) = res {
+                    Poll::Ready(res)
+                } else {
+                    unreachable!()
+                }
+            }
+            ResultState::Waiting(_) => Poll::Pending,
+            ResultState::Consumed => panic!("poll_result called after result was consumed"),
+        }
+    }
+}
 
 /// A trait defining the interface for an executor that can schedule and execute tasks.
-pub(crate) trait Executor {
+pub trait Executor {
     /// Returns `true` if the current executor is the same as this executor.
     fn is_current(&self) -> bool;
 
@@ -31,6 +88,8 @@ pub(crate) trait ArcTaskBase: Send + 'static {
 
 /// A way of scheduling and executing an asynchronous task in the SPDK Event Framework.
 pub(crate) trait ArcTask: ArcTaskBase {
+    type Output: 'static;
+
     /// Schedules a task for execution on its target, consuming the task in the process.
     fn schedule(arc_self: Arc<Self>) {
         let executor = arc_self.executor();
@@ -72,6 +131,10 @@ pub(crate) trait ArcTask: ArcTaskBase {
     /// This method returns `true` if the task was run synchronously. If it returns `false`, the
     /// task could not be executed synchronously and should be scheduled to run later.
     fn run(arc_self: &Arc<Self>) -> bool;
+
+    /// Polls the result of a task, returning `Poll::Pending` if the result is not yet ready, or
+    /// `Poll::Ready` with the result if it is ready.
+    fn poll_result(arc_self: &Arc<Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
 }
 
 /// Clones the [`RawWaker`] for this task.
@@ -113,7 +176,7 @@ unsafe fn waker_drop<W: ArcTask>(data: *const ()) {
 }
 
 /// Gets the [`RawWakerVTable`] used by a [`RawWaker`] to awaken a task.
-fn waker_vtable<W: ArcTask>() -> &'static RawWakerVTable {
+const fn waker_vtable<W: ArcTask>() -> &'static RawWakerVTable {
     &RawWakerVTable::new(
         waker_clone::<W>,
         waker_wake::<W>,
@@ -132,30 +195,82 @@ fn waker_ref<W: ArcTask>(arc_self: &Arc<W>) -> WakerRef<'_> {
     WakerRef::new_unowned(waker)
 }
 
+/// Polls a task for its result without consuming the task.
+///
+/// # Returns
+///
+/// Poll::Pending` if the task has not yet completed, or `Poll::Ready(result)` if the task has
+/// completed and produced a result.
+unsafe fn join_handle_poll_result<J: ArcTask>(
+    data: *const (),
+    cx: &mut Context<'_>,
+) -> Poll<J::Output> {
+    let arc_task = ManuallyDrop::new(Arc::<J>::from_raw(data.cast()));
+
+    ArcTask::poll_result(&arc_task, cx)
+}
+
+/// Drops the task referenced by the given pointer, releasing its resources.
+unsafe fn join_handle_drop<J: ArcTask>(data: *mut ()) {
+    drop(Arc::<J>::from_raw(data.cast()));
+}
+
+static JOIN_HANDLE_VTABLE_MAP: LazyLock<RwLock<HashMap<TypeId, Box<RawJoinHandleVTable<()>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Gets the [`RawJoinHandleVTable`] used by a [`JoinHandle`] to poll a task.
+fn join_handle_vtable<J: ArcTask>() -> &'static RawJoinHandleVTable<J::Output> {
+    if let Some(vtable) = JOIN_HANDLE_VTABLE_MAP
+        .read()
+        .get(&TypeId::of::<J>())
+        .map(|v| unsafe {
+            &*(v as *const Box<RawJoinHandleVTable<()>>
+                as *const Box<RawJoinHandleVTable<J::Output>>)
+        })
+    {
+        return vtable.as_ref();
+    }
+
+    let vtable = unsafe {
+        &*(JOIN_HANDLE_VTABLE_MAP
+            .write()
+            .entry(TypeId::of::<J>())
+            .or_insert_with(|| {
+                mem::transmute(Box::new(RawJoinHandleVTable::new(
+                    join_handle_poll_result::<J>,
+                    join_handle_drop::<J>,
+                )))
+            }) as *const Box<RawJoinHandleVTable<()>>
+            as *const Box<RawJoinHandleVTable<J::Output>>)
+    };
+
+    vtable.as_ref()
+}
+
 /// Orchestrates the execution of a [`Future`].
-pub(crate) struct Task<E, T, F>
+pub(crate) struct Task<E, F, T>
 where
     E: Executor + 'static,
-    T: 'static,
     F: Future<Output = T> + 'static,
+    T: 'static,
 {
     executor: Option<E>,
-    result_sender: UnsafeCell<Option<oneshot::Sender<T>>>,
+    result: Mutex<ResultState<T>>,
     future: RefCell<F>,
 }
 
-unsafe impl<E, T, F> Send for Task<E, T, F>
+unsafe impl<E, F, T> Send for Task<E, F, T>
 where
     E: Executor + 'static,
-    T: 'static,
     F: Future<Output = T> + 'static,
+    T: 'static,
 {
 }
 
-impl<T, F> Task<Thread, T, F>
+impl<F, T> Task<Thread, F, T>
 where
-    T: 'static,
     F: Future<Output = T> + 'static,
+    T: 'static,
 {
     /// Constructs a new task from a [`Future`] to be scheduled on a [`Thread`].
     ///
@@ -166,21 +281,28 @@ where
     /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
     /// used to await the result of executing the `Future`.
     pub(crate) fn with_future(executor: Option<Thread>, fut: F) -> (Arc<Self>, JoinHandle<T>) {
-        let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
             executor,
-            result_sender: UnsafeCell::new(Some(sx)),
+            result: Mutex::new(ResultState::Empty),
             future: RefCell::new(fut),
         });
 
-        (task, JoinHandle::new(rx))
+        let cloned_task = task.clone();
+        let join_handle = unsafe {
+            JoinHandle::new(
+                Arc::into_raw(cloned_task) as *mut _,
+                join_handle_vtable::<Self>(),
+            )
+        };
+
+        (task, join_handle)
     }
 }
 
-impl<T, F> ArcTaskBase for Task<Thread, T, F>
+impl<F, T> ArcTaskBase for Task<Thread, F, T>
 where
-    T: 'static,
     F: Future<Output = T> + 'static,
+    T: 'static,
 {
     fn executor(&self) -> impl Executor + 'static {
         self.executor
@@ -190,7 +312,7 @@ where
     }
 }
 
-impl<T, F> Task<Reactor, T, F>
+impl<F, T> Task<Reactor, F, T>
 where
     T: 'static,
     F: Future<Output = T> + 'static,
@@ -202,18 +324,25 @@ where
     /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
     /// used to await the result of executing the `Future`.
     pub(crate) fn with_future(executor: Reactor, fut: F) -> (Arc<Self>, JoinHandle<T>) {
-        let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
             executor: Some(executor),
-            result_sender: UnsafeCell::new(Some(sx)),
+            result: Mutex::new(ResultState::Empty),
             future: RefCell::new(fut),
         });
 
-        (task, JoinHandle::new(rx))
+        let cloned_task = task.clone();
+        let join_handle = unsafe {
+            JoinHandle::new(
+                Arc::into_raw(cloned_task) as *mut _,
+                join_handle_vtable::<Self>(),
+            )
+        };
+
+        (task, join_handle)
     }
 }
 
-impl<T, F> ArcTaskBase for Task<Reactor, T, F>
+impl<F, T> ArcTaskBase for Task<Reactor, F, T>
 where
     T: 'static,
     F: Future<Output = T> + 'static,
@@ -223,13 +352,15 @@ where
     }
 }
 
-impl<E, T, F> ArcTask for Task<E, T, F>
+impl<E, F, T> ArcTask for Task<E, F, T>
 where
     E: Executor + 'static,
     T: 'static,
     F: Future<Output = T> + 'static,
-    Task<E, T, F>: ArcTaskBase,
+    Task<E, F, T>: ArcTaskBase,
 {
+    type Output = T;
+
     fn run(arc_self: &Arc<Self>) -> bool {
         match arc_self.future.try_borrow_mut() {
             Ok(mut fut) => {
@@ -243,25 +374,25 @@ where
 
                 match fut.poll(&mut ctx) {
                     Poll::Ready(result) => {
-                        // The future has completed, so send the result to the join handle.
-                        let sender = unsafe { &mut *arc_self.result_sender.get() };
+                        let res = arc_self.result.lock().set_result(result);
 
-                        if let Some(sx) = sender.take() {
-                            let _ = sx.send(result);
-                        }
-
-                        true
+                        if let Some(waker) = res {
+                            waker.wake();
+                        };
                     }
-                    // The future is not ready yet, but the call to `poll` set up the task to be
-                    // awakened later. We simply return `true` here to indicate that the task has
-                    // been processed successfully.
-                    Poll::Pending => true,
+                    Poll::Pending => {}
                 }
+
+                true
             }
             // The task was re-entered while its future was already being polled. Return `false` to
             // indicate that the task needs to be scheduled to run by its executor later.
             Err(_) => false,
         }
+    }
+
+    fn poll_result(arc_self: &Arc<Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        arc_self.result.lock().poll_result(cx)
     }
 }
 
@@ -276,7 +407,7 @@ where
     F: Future<Output = T> + 'static,
     T: Send + 'static,
 {
-    let (task, join_handle) = Task::<Thread, T, F>::with_future(Some(thread), fut_gen());
+    let (task, join_handle) = Task::<Thread, F, T>::with_future(Some(thread), fut_gen());
 
     ArcTask::schedule(task);
 
@@ -290,7 +421,7 @@ where
     F: Future<Output = T> + 'static,
     T: 'static,
 {
-    let (task, join_handle) = Task::<Thread, T, F>::with_future(Thread::try_current(), fut);
+    let (task, join_handle) = Task::<Thread, F, T>::with_future(Thread::try_current(), fut);
 
     ArcTask::schedule(task);
 
@@ -308,7 +439,7 @@ where
     F: Future<Output = T> + 'static,
     T: Send + 'static,
 {
-    let (task, join_handle) = Task::<Reactor, T, F>::with_future(reactor, fut_gen());
+    let (task, join_handle) = Task::<Reactor, F, T>::with_future(reactor, fut_gen());
 
     ArcTask::schedule(task);
 
@@ -322,7 +453,7 @@ where
     F: Future<Output = T> + 'static,
     T: 'static,
 {
-    let (task, join_handle) = Task::<Reactor, T, F>::with_future(Reactor::current(), fut);
+    let (task, join_handle) = Task::<Reactor, F, T>::with_future(Reactor::current(), fut);
 
     ArcTask::schedule(task);
 

--- a/spdk/src/task/task.rs
+++ b/spdk/src/task/task.rs
@@ -1,8 +1,7 @@
 use std::{
     cell::{RefCell, UnsafeCell},
-    fmt::Debug,
     future::Future,
-    mem::{self, ManuallyDrop},
+    mem::ManuallyDrop,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
@@ -133,71 +132,6 @@ fn waker_ref<W: ArcTask>(arc_self: &Arc<W>) -> WakerRef<'_> {
     WakerRef::new_unowned(waker)
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
-/// Encapsulates the execution state of a [`Task`].
-///
-/// The following state diagram shows the state transitions of a [`Task`].
-///
-/// ```mermaid
-/// stateDiagram-v2
-/// Pending --> Polling : poll()
-/// Polling --> Polling : poll()
-/// Polling --> Pending : mark_pending()
-/// Polling --> Done : mark_done()
-/// ```
-#[derive(Debug, Eq, PartialEq)]
-enum TaskState {
-    /// The task is pending execution.
-    Pending,
-
-    /// The task is currently being polled.
-    Polling,
-
-    /// The task has completed execution.
-    Done,
-}
-
-impl TaskState {
-    /// Replaces the current state with the specified value and returns the old state.
-    #[inline]
-    fn replace(&mut self, value: Self) -> Self {
-        mem::replace(&mut *self, value)
-    }
-
-    /// Marks the task state as pending.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the current state is not `Polling`.
-    #[inline]
-    fn mark_pending(&mut self) {
-        assert_eq!(self.replace(Self::Pending), Self::Polling);
-    }
-
-    /// Marks the task state as done.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the current state is not `Polling`.
-    #[inline]
-    fn mark_done(&mut self) {
-        assert_eq!(self.replace(Self::Done), Self::Polling);
-    }
-
-    /// Polls the state of the task, advancing to the next state if possible.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if the task is polled in a state other than `Pending` or `Polling`.
-    fn poll(&mut self) -> Self {
-        match self {
-            Self::Pending => self.replace(Self::Polling),
-            Self::Polling => Self::Polling,
-            _ => panic!("task polled in unexpected state: {:?}", self),
-        }
-    }
-}
-
 /// Orchestrates the execution of a [`Future`].
 pub(crate) struct Task<E, T, F>
 where
@@ -206,9 +140,8 @@ where
     F: Future<Output = T> + 'static,
 {
     executor: Option<E>,
-    state: RefCell<TaskState>,
     result_sender: UnsafeCell<Option<oneshot::Sender<T>>>,
-    future: UnsafeCell<F>,
+    future: RefCell<F>,
 }
 
 unsafe impl<E, T, F> Send for Task<E, T, F>
@@ -230,15 +163,14 @@ where
     ///
     /// # Return
     ///
-    /// This function returns both a newly constructed [`ThreadTask`] and a [`JoinHandle`] that can
-    /// be used to await the result of executing the [`Future`].
+    /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
+    /// used to await the result of executing the `Future`.
     pub(crate) fn with_future(executor: Option<Thread>, fut: F) -> (Arc<Self>, JoinHandle<T>) {
         let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
             executor,
-            state: RefCell::new(TaskState::Pending),
             result_sender: UnsafeCell::new(Some(sx)),
-            future: UnsafeCell::new(fut),
+            future: RefCell::new(fut),
         });
 
         (task, JoinHandle::new(rx))
@@ -267,15 +199,14 @@ where
     ///
     /// # Return
     ///
-    /// This function returns both a newly constructed [`ReactorTask`] and a [`JoinHandle`] that can
-    /// be used to await the result of executing the [`Future`].
+    /// This function returns both a newly constructed [`Task`] and a [`JoinHandle`] that can be
+    /// used to await the result of executing the `Future`.
     pub(crate) fn with_future(executor: Reactor, fut: F) -> (Arc<Self>, JoinHandle<T>) {
         let (sx, rx) = oneshot::channel();
         let task = Arc::new(Self {
             executor: Some(executor),
-            state: RefCell::new(TaskState::Pending),
             result_sender: UnsafeCell::new(Some(sx)),
-            future: UnsafeCell::new(fut),
+            future: RefCell::new(fut),
         });
 
         (task, JoinHandle::new(rx))
@@ -300,34 +231,36 @@ where
     Task<E, T, F>: ArcTaskBase,
 {
     fn run(arc_self: &Arc<Self>) -> bool {
-        let state = arc_self.state.borrow_mut().poll();
-
-        match state {
-            TaskState::Pending => {
+        match arc_self.future.try_borrow_mut() {
+            Ok(mut fut) => {
                 let waker = waker_ref(arc_self);
-                let ctx = &mut Context::from_waker(&waker);
+                let mut ctx = Context::from_waker(&waker);
 
-                // SAFETY: The future is only polled when in the `Polling` state (i.e. previous
-                // state was `Pending`). There are no other references to it.
-                let mut fut = unsafe { Pin::new_unchecked(&mut *arc_self.future.get()) };
+                // SAFETY: The future is pinned in place for the duration of this function call, and
+                // it is not moved or dropped until the future is complete. The future is also not
+                // accessed from any other thread, so it is safe to create a pinned reference to it.
+                let fut = unsafe { Pin::new_unchecked(&mut *fut) };
 
-                match fut.as_mut().poll(ctx) {
-                    Poll::Pending => arc_self.state.borrow_mut().mark_pending(),
-                    Poll::Ready(r) => {
-                        // SAFETY: The result sender is only taken when in the `Done` state. There
-                        // are no other references to it.
-                        let _ = unsafe { &mut *arc_self.result_sender.get() }
-                            .take()
-                            .unwrap()
-                            .send(r);
-                        arc_self.state.borrow_mut().mark_done();
+                match fut.poll(&mut ctx) {
+                    Poll::Ready(result) => {
+                        // The future has completed, so send the result to the join handle.
+                        let sender = unsafe { &mut *arc_self.result_sender.get() };
+
+                        if let Some(sx) = sender.take() {
+                            let _ = sx.send(result);
+                        }
+
+                        true
                     }
+                    // The future is not ready yet, but the call to `poll` set up the task to be
+                    // awakened later. We simply return `true` here to indicate that the task has
+                    // been processed successfully.
+                    Poll::Pending => true,
                 }
-
-                true
             }
-            TaskState::Polling => false,
-            _ => unreachable!(),
+            // The task was re-entered while its future was already being polled. Return `false` to
+            // indicate that the task needs to be scheduled to run by its executor later.
+            Err(_) => false,
         }
     }
 }

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -32,7 +32,7 @@ use spdk_sys::{
 use crate::{
     errors::{Errno, ENOMEM},
     runtime::CpuSet,
-    task::{JoinHandle, Task, ThreadTask},
+    task::{self, Executor, JoinHandle},
     to_result,
 };
 
@@ -319,11 +319,20 @@ impl Thread {
         F: Future<Output = T> + 'static,
         T: Send + 'static,
     {
-        let (task, join_handle) = ThreadTask::with_future(Some(self.borrow()), fut_gen());
+        task::spawn_on_thread(self.borrow(), fut_gen)
+    }
+}
 
-        Task::schedule(task);
+impl Executor for Thread {
+    fn is_current(&self) -> bool {
+        self.is_current()
+    }
 
-        join_handle
+    fn schedule<F>(&self, f: F)
+    where
+        F: FnOnce() + 'static,
+    {
+        self.send_msg(f).expect("thread message sent");
     }
 }
 
@@ -362,11 +371,7 @@ where
     F: Future<Output = T> + 'static,
     T: 'static,
 {
-    let (task, join_handle) = ThreadTask::with_future(Some(Thread::current()), fut);
-
-    Task::schedule(task);
-
-    join_handle
+    task::spawn_on_current_thread(fut)
 }
 
 /// Runs the provided future on the current SPDK thread until completion.
@@ -384,9 +389,7 @@ where
     T: Send + 'static,
 {
     let current_thread = Thread::current();
-    let (task, mut join_handle) = ThreadTask::with_future(Some(current_thread.borrow()), fut);
-
-    Task::schedule_by_ref(&task);
+    let mut join_handle = task::spawn_on_current_thread(fut);
 
     loop {
         match Pin::new(&mut join_handle).rx_pin_mut().try_recv() {

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -20,8 +20,10 @@ use std::{
     mem::MaybeUninit,
     pin::Pin,
     ptr::NonNull,
+    task::{Context, Poll},
 };
 
+use futures::task::noop_waker_ref;
 use spdk_sys::{
     spdk_cpuset_copy, spdk_get_thread, spdk_thread, spdk_thread_bind, spdk_thread_create,
     spdk_thread_exit, spdk_thread_get_app_thread, spdk_thread_get_by_id, spdk_thread_get_cpumask,
@@ -392,10 +394,12 @@ where
     let mut join_handle = task::spawn_on_current_thread(fut);
 
     loop {
-        match Pin::new(&mut join_handle).rx_pin_mut().try_recv() {
-            Ok(Some(r)) => return r,
-            Ok(None) => _ = current_thread.poll(),
-            Err(_) => panic!("sender dropped"),
+        if let Poll::Ready(res) =
+            Pin::new(&mut join_handle).poll(&mut Context::from_waker(noop_waker_ref()))
+        {
+            return res;
         }
+
+        current_thread.poll();
     }
 }


### PR DESCRIPTION
This change optimizes the spawning of asynchronous task on the current executor: `Reactor` or `Thread`. It avoids the use of unnecessary interlocked operations when spawning an asynchronous task locally.