### PR TITLE
chore: specify associated `BDevOps` implementation in `ModuleOps`

### DIFF
--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -26,7 +26,7 @@ struct EchoModule;
 
 #[async_trait(?Send)]
 impl ModuleOps for EchoModule {
-    type IoContext = ();
+    type BDev = Echo;
 
     async fn init(&self) {
         task::yield_now().await;

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -15,7 +15,7 @@ struct NullRsModule;
 
 #[async_trait(?Send)]
 impl ModuleOps for NullRsModule {
-    type IoContext = ();
+    type BDev = NullRs;
 }
 
 /// Implements the NullRs block device I/O channel. It ignores write requests

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -19,7 +19,7 @@ struct PassthruRsModule;
 
 #[async_trait(?Send)]
 impl ModuleOps for PassthruRsModule {
-    type IoContext = ();
+    type BDev = PassthruRs;
 }
 
 struct PassthruRsChannel {

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -109,7 +109,11 @@ impl From<IoStatus> for spdk_bdev_io_status {
 /// A trait for implementing the I/O channel operations for a BDev.
 #[async_trait(?Send)]
 pub trait BDevIoChannelOps: 'static {
-    /// The I/O context type for the BDev.
+    /// A per-I/O context type accessed through the [`BDevIo::ctx()`] and
+    /// [`BDevIo::ctx_mut()`] methods.
+    ///
+    /// [`BDevIo::ctx()`]: method@super::BDevIo::ctx
+    /// [`BDevIo::ctx_mut()`]: method@super::BDevIo::ctx_mut
     type IoContext: Default + 'static;
 
     /// Submit an I/O request to the BDev.
@@ -185,7 +189,7 @@ where
 ///
 /// The type parameter `T` is the I/O context type for the BDev implementation.
 #[derive(Default)]
-pub(crate) struct BDevIoCtx<T>
+struct BDevIoCtx<T>
 where
     T: Default + 'static,
 {
@@ -412,6 +416,11 @@ pub trait BDevOps: Send + Sync + 'static {
 
     /// Creates a new I/O channel for the BDev.
     fn new_io_channel(&mut self) -> Result<Self::IoChannel, Errno>;
+
+    /// Returns the size in bytes of the per-I/O context.
+    fn get_io_context_size() -> usize {
+        size_of::<BDevIoCtx<<<Self as BDevOps>::IoChannel as BDevIoChannelOps>::IoContext>>()
+    }
 }
 
 /// A BDev implementation.

--- a/spdk/src/bdev/mod.rs
+++ b/spdk/src/bdev/mod.rs
@@ -17,8 +17,6 @@ mod bdev;
 mod module;
 
 #[cfg(feature = "bdev-module")]
-pub(crate) use bdev::BDevIoCtx;
-#[cfg(feature = "bdev-module")]
 pub use bdev::{BDevImpl, BDevIo, BDevIoChannel, BDevIoChannelOps, BDevOps, IoStatus};
 
 #[cfg(feature = "bdev-module")]

--- a/spdk/src/bdev/module.rs
+++ b/spdk/src/bdev/module.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, fmt::Debug, mem::size_of};
+use std::{ffi::CStr, fmt::Debug};
 
 use async_trait::async_trait;
 use spdk_sys::{
@@ -11,17 +11,13 @@ use crate::{
     thread::{self},
 };
 
-use super::{BDevImpl, BDevIoCtx, BDevOps};
+use super::{BDevImpl, BDevOps};
 
 /// A trait defining BDev module operations.
 #[async_trait(?Send)]
 pub trait ModuleOps {
-    /// A per-I/O context type accessed through the [`BDevIo::ctx()`] and
-    /// [`BDevIo::ctx_mut()`] methods.
-    ///
-    /// [`BDevIo::ctx()`]: method@super::BDevIo::ctx
-    /// [`BDevIo::ctx_mut()`]: method@super::BDevIo::ctx_mut
-    type IoContext: Default + 'static;
+    /// The BDev type implemented by the module.
+    type BDev: BDevOps;
 
     /// Initializes the module.
     async fn init(&self) {}
@@ -29,9 +25,9 @@ pub trait ModuleOps {
     /// Finalizes the module.
     async fn fini(&self) {}
 
-    /// Returns the size of the per-I/O context.
+    /// Returns the size in bytes of the per-I/O context.
     fn get_io_context_size(&self) -> usize {
-        size_of::<BDevIoCtx<Self::IoContext>>()
+        Self::BDev::get_io_context_size()
     }
 
     /// Examines the specified block device to determine whether it should be
@@ -165,7 +161,7 @@ where
         });
     }
 
-    /// Returns the size of the per-I/O context.
+    /// Returns the size in bytes of the per-I/O context.
     unsafe extern "C" fn get_io_context_size() -> i32 {
         T::instance().get_io_context_size() as i32
     }


### PR DESCRIPTION
This changes the associated type of `ModuleOps` to a `BDevOps` type rather than the per-I/O context type. This avoids the possibility of errors, e.g. choosing different `IoContext` types in the `ModuleOps` and `BDevIoChannelOps` implementations.