### PR TITLE
fix: terminates the `app_long_opts` array properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
  "rustversion",
  "strum",
  "strum_macros",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror",
 ]
 
@@ -305,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -417,7 +417,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -767,18 +767,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -896,7 +896,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "ternary-rs",
 ]
 
@@ -1030,7 +1030,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1097,7 +1097,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1242,7 +1242,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/spdk-macros/Cargo.toml
+++ b/spdk-macros/Cargo.toml
@@ -11,9 +11,9 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.11.0"
-proc-macro2 = "1.0.106"
-quote = "1.0.46"
-syn = { version = "2.0.118", features = ["full", "visit"] }
+proc-macro2 = "1.0.107"
+quote = "1.0.47"
+syn = { version = "2.0.119", features = ["full", "visit"] }
 ternary-rs = "1.0.0"
 
 [features]

--- a/spdk-macros/src/cli.rs
+++ b/spdk-macros/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, ffi::CString, os::raw::c_int};
+use std::{cell::Cell, ffi::CString, iter::once, os::raw::c_int};
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
@@ -308,6 +308,7 @@ impl DeriveParser {
     ///
     /// [`Parser`]: ../../spdk/cli/trait.Parser.html
     pub(crate) fn derive(&mut self, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+        // Parse the input structure to extract the field definitions into a `Vec` of `Arg` structures.
         let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
         let fields = match input.data {
@@ -338,10 +339,23 @@ impl DeriveParser {
         let uppername = type_ident.to_string().to_uppercase();
         let current_value_ident = format_ident!("{}_CURRENT_VALUE", uppername);
 
+        // Generate the initializers for the default value of each arg.
         let field_inits = args.iter().map(Arg::field_init);
+
+        // Generate the parse options match clauses.
         let parse_opts = args.iter().map(Arg::parse_option);
-        let long_opt = args.iter().map(Arg::long_opt);
-        let long_opts_count = long_opt.len();
+
+        // Generate the long options array, appending a zeroed structure at the end.
+        let long_opts: Vec<_> = args
+            .iter()
+            .map(Arg::long_opt)
+            .chain(once(quote! {
+                unsafe { std::mem::MaybeUninit::zeroed().assume_init() }
+            }))
+            .collect();
+        let long_opts_count = long_opts.len();
+
+        // Generate the `getopts` string for short options.
         let getopts_str = CString::new(args.iter().map(Arg::getopts_str).fold(
             String::new(),
             |mut acc, s| {
@@ -352,9 +366,14 @@ impl DeriveParser {
         ))
         .unwrap();
         let getopts_str_lit = LitCStr::new(&getopts_str, type_ident.span());
+
+        // Generate the help text.
         let help = args.iter().flat_map(Arg::help);
+
+        // Accumulate the errors encountered while parsing the input.
         let errors = args.iter().flat_map(Arg::errors);
 
+        // Render the output token stream.
         let output = quote! {
             #(#errors)*
 
@@ -409,7 +428,7 @@ impl DeriveParser {
                         .collect();
 
                     let custom_opts: [spdk_sys::option; #long_opts_count] = [
-                        #(#long_opt),*
+                        #(#long_opts),*
                     ];
 
                     unsafe {


### PR DESCRIPTION
This change properly terminates the `app_long_opts` array passed to `spdk_app_parse_args` with a zeroed-filled entry.

This change also updates the `proc-macro2`, `quote` & `syn` crates to the latest versions.