### PR TITLE
feat: allow for more conversions to/from `Errno`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
  "libc",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
  "ternary-rs",
 ]
 
@@ -1039,6 +1039,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,16 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +939,6 @@ dependencies = [
  "aquamarine",
  "async-condvar-fair",
  "async-trait",
- "errno",
  "futures",
  "laboratory",
  "libc",
@@ -966,6 +955,7 @@ name = "spdk-macros"
 version = "0.1.0"
 dependencies = [
  "convert_case 0.11.0",
+ "libc",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/spdk-macros/Cargo.toml
+++ b/spdk-macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.11.0"
+libc = "0.2.186"
 proc-macro2 = "1.0.107"
 quote = "1.0.47"
 syn = { version = "2.0.119", features = ["full", "visit"] }

--- a/spdk-macros/Cargo.toml
+++ b/spdk-macros/Cargo.toml
@@ -14,7 +14,7 @@ convert_case = "0.11.0"
 libc = "0.2.186"
 proc-macro2 = "1.0.107"
 quote = "1.0.47"
-syn = { version = "2.0.119", features = ["full", "visit"] }
+syn = { version = "3.0.0", features = ["full", "visit"] }
 ternary-rs = "1.0.0"
 
 [features]

--- a/spdk-macros/src/define_errno.rs
+++ b/spdk-macros/src/define_errno.rs
@@ -1,0 +1,91 @@
+use std::ffi::CStr;
+
+use quote::{quote, quote_spanned};
+use syn::{
+    parse::Parse,
+    parse_macro_input,
+    punctuated::{IntoIter, Punctuated},
+    spanned::Spanned,
+    Expr, ExprAssign, Token,
+};
+
+struct ErrnoList(Punctuated<ExprAssign, Token![,]>);
+
+impl IntoIterator for ErrnoList {
+    type Item = ExprAssign;
+
+    type IntoIter = IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Parse for ErrnoList {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self(Punctuated::<ExprAssign, Token![,]>::parse_terminated(
+            input,
+        )?))
+    }
+}
+
+pub(crate) struct DefineErrno {}
+
+impl DefineErrno {
+    /// Creates a new instance of `DefineErrno`.
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    /// Generates the `Errno` constant definitions from a comma-delimited list of simple assignment
+    /// expressions in the form given by the regular expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`.
+    pub(crate) fn generate(&mut self, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+        let input = parse_macro_input!(item as ErrnoList);
+        let (defs, errors): (_, _) = input
+            .into_iter()
+            .map(|e| {
+                let name = match &*e.left {
+                    Expr::Path(p) if p.path.segments.len() == 1 => {
+                        p.path.segments.first().unwrap().ident.clone()
+                    }
+                    _ => {
+                        return Err(
+                            syn::Error::new(e.left.span(), "expected a plain identifier")
+                                .to_compile_error(),
+                        );
+                    }
+                };
+
+                let val: i32 = match &*e.right {
+                    Expr::Lit(l) if let syn::Lit::Int(l) = &l.lit => l
+                        .base10_parse()
+                        .map_err(|e| syn::Error::to_compile_error(&e))?,
+                    _ => {
+                        return Err(
+                            syn::Error::new(e.right.span(), "expected a numeric literal")
+                                .to_compile_error(),
+                        )
+                    }
+                };
+
+                let msg = unsafe { &CStr::from_ptr(libc::strerror(val)).to_string_lossy() };
+
+                Ok(quote_spanned! {e.span()=>
+                    #[doc = #msg]
+                    pub const #name: Errno = Errno(#val);
+
+                })
+            })
+            .partition::<Vec<_>, _>(Result::is_ok);
+
+        let defs = defs.into_iter().map(Result::ok);
+        let errors = errors.into_iter().map(Result::err);
+
+        let output = quote! {
+            #(#errors)*
+            #(#defs)*
+        };
+
+        output.into()
+    }
+}

--- a/spdk-macros/src/lib.rs
+++ b/spdk-macros/src/lib.rs
@@ -1,5 +1,6 @@
 //! Procedural macros for the spdk crate.
 mod cli;
+mod define_errno;
 mod main_attr;
 
 #[cfg(feature = "bdev-module")]
@@ -311,4 +312,24 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
     module::GenerateModule::new().generate(attr, item)
+}
+
+/// Generates `Errno` constant definitions for the `errors` module of the `spdk` crate.
+///
+/// The macro takes a comma-delimited list of simple expression assignments given by the
+/// regular expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`, and generates `Errno` constant
+/// definitions. The definitions include automatically generated documentation by passing the value
+/// to the [`strerror`] function.
+///
+/// <div class="warning">
+///
+/// **NOTE:** This macro is intended only for use by the `spdk` crate for its `Errno` definitions.
+/// The macro defintion and usage is subject to change without notice.
+///
+/// </div>
+///
+/// [`strerror`]: https://www.man7.org/linux/man-pages/man3/strerror.3.html
+#[proc_macro]
+pub fn define_errno(item: TokenStream) -> TokenStream {
+    define_errno::DefineErrno::new().generate(item)
 }

--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -10,7 +10,6 @@ all-features = true
 [dependencies]
 aquamarine = "0.6.0"
 async-trait = "0.1.89"
-errno = "0.3.14"
 futures = "0.3.32"
 libc = "0.2.186"
 parking_lot = "0.12.5"

--- a/spdk/src/block/descriptor.rs
+++ b/spdk/src/block/descriptor.rs
@@ -32,7 +32,7 @@ impl Descriptor {
         let res = if_else!(
             status == 0,
             Descriptor::try_from(desc).map_err(|_| EINVAL),
-            Err(Errno(-status))
+            Err(Errno::new(-status))
         );
 
         Promissory::set_result(p, res);

--- a/spdk/src/errors.rs
+++ b/spdk/src/errors.rs
@@ -1,40 +1,256 @@
 //! Common error definitions.
+use std::{
+    error::Error,
+    ffi::CStr,
+    fmt::{Debug, Display},
+    io::ErrorKind,
+};
+
 use libc;
+use spdk_macros::define_errno;
 
-pub use errno::Errno;
+/// Returns the last error set by a system or library call.
+pub fn errno() -> Errno {
+    Errno(unsafe { *libc::__errno_location() })
+}
 
-/// Operation not permitted
-pub const EPERM: Errno = Errno(libc::EPERM);
+/// A wrapper around a Linux error code.
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Errno(#[doc = "A linux error code."] i32);
 
-/// No such file or directory
-pub const ENOENT: Errno = Errno(libc::ENOENT);
+impl Errno {
+    /// Creates a new `Errno` from a Linux error code.
+    pub const fn new(errno: i32) -> Self {
+        Self(errno)
+    }
 
-/// Input/output error
-pub const EIO: Errno = Errno(libc::EIO);
+    /// Returns the Linux error code wrapped by this instance.
+    pub fn errno(&self) -> i32 {
+        self.0
+    }
+}
 
-/// Bad file descriptor
-pub const EBADF: Errno = Errno(libc::EBADF);
+impl Display for Errno {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = unsafe { &CStr::from_ptr(libc::strerror(self.0)).to_string_lossy() };
 
-/// Not enough space/cannot allocate memory
-pub const ENOMEM: Errno = Errno(libc::ENOMEM);
+        f.write_str(msg)
+    }
+}
 
-/// No such device
-pub const ENODEV: Errno = Errno(libc::ENODEV);
+impl Debug for Errno {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Errno").field(&self.0).finish()
+    }
+}
 
-/// Invalid argument
-pub const EINVAL: Errno = Errno(libc::EINVAL);
+impl Error for Errno {}
 
-/// Out of range
-pub const ERANGE: Errno = Errno(libc::ERANGE);
+define_errno! {
+    EPERM = 1,
+    ENOENT = 2,
+    ESRCH = 3,
+    EINTR = 4,
+    EIO = 5,
+    ENXIO = 6,
+    E2BIG = 7,
+    ENOEXEC = 8,
+    EBADF = 9,
+    ECHILD = 10,
+    EAGAIN = 11,
+    ENOMEM = 12,
+    EACCES = 13,
+    EFAULT = 14,
+    ENOTBLK = 15,
+    EBUSY = 16,
+    EEXIST = 17,
+    EXDEV = 18,
+    ENODEV = 19,
+    ENOTDIR = 20,
+    EISDIR = 21,
+    EINVAL = 22,
+    ENFILE = 23,
+    EMFILE = 24,
+    ENOTTY = 25,
+    ETXTBSY = 26,
+    EFBIG = 27,
+    ENOSPC = 28,
+    ESPIPE = 29,
+    EROFS = 30,
+    EMLINK = 31,
+    EPIPE = 32,
+    EDOM = 33,
+    ERANGE = 34,
+    EDEADLK = 35,
+    ENAMETOOLONG = 36,
+    ENOLCK = 37,
+    ENOSYS = 38,
+    ENOTEMPTY = 39,
+    ELOOP = 40,
+    ENOMSG = 42,
+    EIDRM = 43,
+    ECHRNG = 44,
+    EL2NSYNC = 45,
+    EL3HLT = 46,
+    EL3RST = 47,
+    ELNRNG = 48,
+    EUNATCH = 49,
+    ENOCSI = 50,
+    EL2HLT = 51,
+    EBADE = 52,
+    EBADR = 53,
+    EXFULL = 54,
+    ENOANO = 55,
+    EBADRQC = 56,
+    EBADSLT = 57,
+    EBFONT = 59,
+    ENOSTR = 60,
+    ENODATA = 61,
+    ETIME = 62,
+    ENOSR = 63,
+    ENONET = 64,
+    ENOPKG = 65,
+    EREMOTE = 66,
+    ENOLINK = 67,
+    EADV = 68,
+    ESRMNT = 69,
+    ECOMM = 70,
+    EPROTO = 71,
+    EMULTIHOP = 72,
+    EDOTDOT = 73,
+    EBADMSG = 74,
+    EOVERFLOW = 75,
+    ENOTUNIQ = 76,
+    EBADFD = 77,
+    EREMCHG = 78,
+    ELIBACC = 79,
+    ELIBBAD = 80,
+    ELIBSCN = 81,
+    ELIBMAX = 82,
+    ELIBEXEC = 83,
+    EILSEQ = 84,
+    ERESTART = 85,
+    ESTRPIPE = 86,
+    EUSERS = 87,
+    ENOTSOCK = 88,
+    EDESTADDRREQ = 89,
+    EMSGSIZE = 90,
+    EPROTOTYPE = 91,
+    ENOPROTOOPT = 92,
+    EPROTONOSUPPORT = 93,
+    ESOCKTNOSUPPORT = 94,
+    EOPNOTSUPP = 95,
+    EPFNOSUPPORT = 96,
+    EAFNOSUPPORT = 97,
+    EADDRINUSE = 98,
+    EADDRNOTAVAIL = 99,
+    ENETDOWN = 100,
+    ENETUNREACH = 101,
+    ENETRESET = 102,
+    ECONNABORTED = 103,
+    ECONNRESET = 104,
+    ENOBUFS = 105,
+    EISCONN = 106,
+    ENOTCONN = 107,
+    ESHUTDOWN = 108,
+    ETOOMANYREFS = 109,
+    ETIMEDOUT = 110,
+    ECONNREFUSED = 111,
+    EHOSTDOWN = 112,
+    EHOSTUNREACH = 113,
+    EALREADY = 114,
+    EINPROGRESS = 115,
+    ESTALE = 116,
+    EDQUOT = 122,
+    ENOMEDIUM = 123,
+    EMEDIUMTYPE = 124,
+    ECANCELED = 125,
+    ENOKEY = 126,
+    EKEYEXPIRED = 127,
+    EKEYREVOKED = 128,
+    EKEYREJECTED = 129,
+    EOWNERDEAD = 130,
+    ENOTRECOVERABLE = 131,
+    EHWPOISON = 133,
+    ERFKILL = 132,
+}
 
-/// Operation not supported
-pub const ENOTSUP: Errno = Errno(libc::ENOTSUP);
+define_errno! {
+    EWOULDBLOCK = 11,
+    ENOTSUP = 95,
+}
 
-/// Operation already in progress
-pub const EALREADY: Errno = Errno(libc::EALREADY);
+impl From<i32> for Errno {
+    fn from(i: i32) -> Self {
+        Self(i)
+    }
+}
 
-/// Operation in progress
-pub const EINPROGRESS: Errno = Errno(libc::EINPROGRESS);
+impl From<std::io::Error> for Errno {
+    fn from(e: std::io::Error) -> Self {
+        if let Some(e) = e.raw_os_error() {
+            return Errno(e);
+        }
 
-/// Operation canceled
-pub const ECANCELED: Errno = Errno(libc::ECANCELED);
+        e.kind().into()
+    }
+}
+
+impl From<ErrorKind> for Errno {
+    fn from(value: ErrorKind) -> Self {
+        match value {
+            ErrorKind::NotFound => ENOENT,
+            ErrorKind::PermissionDenied => EPERM,
+            ErrorKind::ConnectionRefused => ECONNREFUSED,
+            ErrorKind::ConnectionReset => ECONNRESET,
+            ErrorKind::HostUnreachable => EHOSTUNREACH,
+            ErrorKind::NetworkUnreachable => ENETUNREACH,
+            ErrorKind::ConnectionAborted => ECONNABORTED,
+            ErrorKind::NotConnected => ENOTCONN,
+            ErrorKind::AddrInUse => EADDRINUSE,
+            ErrorKind::AddrNotAvailable => EADDRNOTAVAIL,
+            ErrorKind::NetworkDown => ENETDOWN,
+            ErrorKind::BrokenPipe => EPIPE,
+            ErrorKind::AlreadyExists => EEXIST,
+            ErrorKind::WouldBlock => EWOULDBLOCK,
+            ErrorKind::NotADirectory => ENOTDIR,
+            ErrorKind::IsADirectory => EISDIR,
+            ErrorKind::DirectoryNotEmpty => ENOTEMPTY,
+            ErrorKind::ReadOnlyFilesystem => EROFS,
+            ErrorKind::StaleNetworkFileHandle => ESTALE,
+            ErrorKind::InvalidInput => EINVAL,
+            ErrorKind::InvalidData => EINVAL,
+            ErrorKind::TimedOut => ETIME,
+            ErrorKind::WriteZero => EMSGSIZE,
+            ErrorKind::StorageFull => ENOSPC,
+            ErrorKind::NotSeekable => ESPIPE,
+            ErrorKind::QuotaExceeded => EDQUOT,
+            ErrorKind::FileTooLarge => EFBIG,
+            ErrorKind::ResourceBusy => EBUSY,
+            ErrorKind::ExecutableFileBusy => EBUSY,
+            ErrorKind::Deadlock => EDEADLK,
+            ErrorKind::CrossesDevices => EXDEV,
+            ErrorKind::TooManyLinks => EMLINK,
+            ErrorKind::InvalidFilename => EINVAL,
+            ErrorKind::ArgumentListTooLong => E2BIG,
+            ErrorKind::Interrupted => EINTR,
+            ErrorKind::Unsupported => ENOTSUP,
+            ErrorKind::UnexpectedEof => EIO,
+            ErrorKind::OutOfMemory => ENOMEM,
+            ErrorKind::Other => EIO,
+            _ => EIO,
+        }
+    }
+}
+
+impl From<Errno> for i32 {
+    fn from(e: Errno) -> i32 {
+        e.0
+    }
+}
+
+impl From<Errno> for std::io::Error {
+    fn from(e: Errno) -> std::io::Error {
+        std::io::Error::from_raw_os_error(e.0)
+    }
+}

--- a/spdk/src/macros.rs
+++ b/spdk/src/macros.rs
@@ -6,10 +6,12 @@
 #[macro_export]
 macro_rules! to_result {
     ($r:expr) => {
-        match $crate::errors::Errno($r) {
-            $crate::errors::Errno(0) => Ok(()),
-            $crate::errors::Errno(e) if e < 0 => Err($crate::errors::Errno(-e)),
-            _ => unreachable!(),
+        match $r {
+            0 => Ok(()),
+            e if e < 0 => Err($crate::errors::Errno::new(-e)),
+            _ => unreachable!(
+                "unexpected postive error value; perhaps you meant to use to_result_size here"
+            ),
         }
     };
 }
@@ -25,7 +27,7 @@ macro_rules! to_result_size {
     ($r:expr) => {
         match { $r } {
             r if r >= 0 => Ok(r as usize),
-            e => Err($crate::errors::Errno(-e as i32)),
+            e => Err($crate::errors::Errno::new(-e as i32)),
         }
     };
 }


### PR DESCRIPTION
Allow for more conversions to/from `Errno` by making it a proper `spdk` type rather than a re-export of the `errno` crate.

This change also adds a `define_errno!` macro to simplify `Errno` constant generation with automatically generated documentation.