### PR TITLE
chore: avoids separate allocation for `Promise` start function

### DIFF
--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -352,14 +352,17 @@ where
     /// Any buffers allocated by this method will automatically be freed on
     /// completion of this I/O request.
     pub async fn allocate_buffers(&mut self, length: u64) -> Result<(), Errno> {
-        Promise::new(move |p| {
-            self.internal_ctx_mut().buf_promissory.replace(p.clone());
+        Promise::new()
+            .request(move |p| {
+                self.internal_ctx_mut().buf_promissory.replace(p.clone());
 
-            unsafe { spdk_bdev_io_get_buf(self.as_ptr(), Some(Self::buffers_allocated), length) };
+                unsafe {
+                    spdk_bdev_io_get_buf(self.as_ptr(), Some(Self::buffers_allocated), length)
+                };
 
-            Poll::Pending
-        })
-        .await
+                Poll::Pending
+            })
+            .await
     }
 
     /// Completes the I/O request with the specified status.
@@ -497,16 +500,17 @@ where
     pub async fn unregister(self: Box<Self>) -> Result<(), Errno> {
         let bdev_ptr = self.into_bdev_ptr();
 
-        Promise::new(move |p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+        Promise::new()
+            .request(move |p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-            unsafe {
-                spdk_bdev_unregister(bdev_ptr, Some(cb_fn), cb_arg.cast_mut() as *mut _);
-            }
+                unsafe {
+                    spdk_bdev_unregister(bdev_ptr, Some(cb_fn), cb_arg.cast_mut() as *mut _);
+                }
 
-            Poll::Pending
-        })
-        .await
+                Poll::Pending
+            })
+            .await
     }
 
     /// Consumes the boxed instance and returns a [`Device<Owned>`] instance
@@ -658,7 +662,7 @@ impl<T: BDevOps> OwnedImpl<T> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<T: BDevOps> OwnedOps for OwnedImpl<T> {
     fn as_ptr(&self) -> *mut spdk_bdev {
         addr_of!(self.0.bdev) as *mut _
@@ -670,16 +674,17 @@ impl<T: BDevOps> OwnedOps for OwnedImpl<T> {
         // avoid dropping the box here to prevent double-free.
         let bdev = ManuallyDrop::new(self);
 
-        Promise::new(move |p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+        Promise::new()
+            .request(move |p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-            unsafe {
-                spdk_bdev_unregister(bdev.as_ptr(), Some(cb_fn), cb_arg.cast_mut() as *mut _);
-            }
+                unsafe {
+                    spdk_bdev_unregister(bdev.as_ptr(), Some(cb_fn), cb_arg.cast_mut() as *mut _);
+                }
 
-            Poll::Pending
-        })
-        .await
+                Poll::Pending
+            })
+            .await
     }
 }
 

--- a/spdk/src/bdev/malloc.rs
+++ b/spdk/src/bdev/malloc.rs
@@ -90,27 +90,28 @@ pub struct Malloc(NonNull<spdk_bdev>);
 
 unsafe impl Send for Malloc {}
 
-#[async_trait]
+#[async_trait(?Send)]
 impl OwnedOps for Malloc {
     fn as_ptr(&self) -> *mut spdk_bdev {
         self.0.as_ptr()
     }
 
     async fn destroy(self) -> Result<(), Errno> {
-        Promise::new(move |p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+        Promise::new()
+            .request(move |p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-            unsafe {
-                delete_malloc_disk(
-                    spdk_bdev_get_name(self.as_ptr()),
-                    Some(cb_fn),
-                    cb_arg.cast_mut() as *mut _,
-                );
-            }
+                unsafe {
+                    delete_malloc_disk(
+                        spdk_bdev_get_name(self.as_ptr()),
+                        Some(cb_fn),
+                        cb_arg.cast_mut() as *mut _,
+                    );
+                }
 
-            Poll::Pending
-        })
-        .await
+                Poll::Pending
+            })
+            .await
     }
 }
 

--- a/spdk/src/block/any.rs
+++ b/spdk/src/block/any.rs
@@ -10,7 +10,7 @@ pub struct Any;
 
 unsafe impl Send for Any {}
 
-#[async_trait]
+#[async_trait(?Send)]
 impl OwnedOps for Any {
     fn as_ptr(&self) -> *mut spdk_bdev {
         unreachable!("Any::as_ptr() should never be called")

--- a/spdk/src/block/descriptor.rs
+++ b/spdk/src/block/descriptor.rs
@@ -40,27 +40,28 @@ impl Descriptor {
 
     /// Open a block device by its name.
     pub async fn open(name: &CStr, write: bool) -> Result<Descriptor, Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = (Self::open_complete, Promissory::into_raw(p.clone()));
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) = (Self::open_complete, Promissory::into_raw(p.clone()));
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_bdev_open_async(
-                        name.as_ptr(),
-                        write,
-                        Some(Self::handle_event),
-                        null_mut(),
-                        null_mut(),
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _,
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_bdev_open_async(
+                            name.as_ptr(),
+                            write,
+                            Some(Self::handle_event),
+                            null_mut(),
+                            null_mut(),
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _,
+                        )
+                    }
+                    => on ready {
+                        unsafe {drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe {drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Returns a pointer to the underlying `spdk_bdev_desc` struct.

--- a/spdk/src/block/io_channel.rs
+++ b/spdk/src/block/io_channel.rs
@@ -1,10 +1,10 @@
 use std::{
     fmt::{self, Debug, Formatter},
     io::{IoSlice, IoSliceMut},
-    mem::zeroed,
+    mem,
     os::raw::c_void,
     ptr::{addr_of, addr_of_mut, NonNull},
-    rc::Rc,
+    rc::{Rc, Weak},
     task::Poll,
 };
 
@@ -28,6 +28,31 @@ use crate::{
 };
 
 use super::{Any, Descriptor, Device};
+
+/// A wrapper around [`spdk_bdev_io_wait_entry`] that manages ownership of a weak pointer to the
+/// [`Promissory`] instance awaiting availability of an [`spdk_bdev_io`] structure.
+struct IoWait(spdk_bdev_io_wait_entry);
+
+impl IoWait {
+    /// Creates a new instance of an `IoWait` structure.
+    fn new(p: &Weak<Promissory<(), IoWait>>, channel: &IoChannel) -> Self {
+        let mut wait: spdk_bdev_io_wait_entry = unsafe { mem::zeroed() };
+
+        wait.bdev = channel.bdev();
+        wait.cb_fn = Some(IoChannel::wait_io_complete);
+        wait.cb_arg = p.clone().into_raw() as *mut _;
+
+        Self(wait)
+    }
+}
+
+impl Drop for IoWait {
+    fn drop(&mut self) {
+        drop(unsafe {
+            Rc::from_raw(self.0.cb_arg as *const Promissory<(), spdk_bdev_io_wait_entry>)
+        });
+    }
+}
 
 /// A handle to a block device I/O channel.
 pub struct IoChannel {
@@ -79,15 +104,15 @@ impl IoChannel {
         self.channel.as_ptr()
     }
 
-    /// A callback invoked when a block device I/O operation completes.
-    unsafe extern "C" fn io_complete(io: *mut spdk_bdev_io, success: bool, cx: *mut c_void) {
-        unsafe {
-            spdk_bdev_free_io(io);
-        }
+    /// A callback invoked when an [`spdk_bdev_io`] structure is available to satisfy the request
+    /// queued by [`spdk_bdev_queue_io_wait`].
+    unsafe extern "C" fn wait_io_complete(ctx: *mut c_void) {
+        let w = Weak::from_raw(ctx as *const _ as *const Promissory<(), IoWait>);
 
-        let p = Promissory::<()>::from_raw(cx.cast());
-
-        Promissory::set_result(p, if_else!(success, Ok(()), Err(EIO)));
+        Promissory::set_result(
+            w.upgrade().expect("promissory has strong references"),
+            Ok(()),
+        );
     }
 
     /// Waits for an I/O to become available.
@@ -102,38 +127,32 @@ impl IoChannel {
     /// This function returns `Err(EINVAL)` if the I/O channel an I/O buffer is
     /// available on the current thread..
     async fn wait_io_available(&self) -> Result<(), Errno> {
-        Promise::with_context(unsafe { zeroed::<spdk_bdev_io_wait_entry>() }, |p| {
-            // SAFETY: The caller guarantees that there are no other
-            // references to the `Promissory` instance, so we can safely get
-            // a mutable reference to the user context. We convert the
-            // mutable reference to a pointer so we can get the callback and
-            // context from the `Rc<Promissory>` instance to store in the
-            // context.
-            let wait = addr_of_mut!(*Promissory::user_context_mut(p).expect("sole reference"));
-            let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
+        Promise::with_context_cyclic(|w| IoWait::new(w, self))
+            .request(|p| {
+                let wait: &IoWait = Promissory::user_context(p);
 
-            // SAFETY: The memory referenced by `wait` has been zeroed, so
-            // overwriting its field is safe.
-            unsafe {
-                addr_of_mut!((*wait).bdev).write(self.bdev());
-                addr_of_mut!((*wait).cb_fn).write(Some(cb_fn));
-                addr_of_mut!((*wait).cb_arg).write(cb_arg.cast_mut() as *mut _);
-            }
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_bdev_queue_io_wait(
+                            self.bdev(),
+                            self.channel.as_ptr(),
+                            &wait.0 as *const _ as *mut _
+                        )
+                    }
+                }
+            })
+            .await
+    }
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_bdev_queue_io_wait(
-                        self.bdev(),
-                        self.channel.as_ptr(),
-                        wait
-                    )
-                }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+    /// A callback invoked when a block device I/O operation completes.
+    unsafe extern "C" fn io_complete(io: *mut spdk_bdev_io, success: bool, cx: *mut c_void) {
+        unsafe {
+            spdk_bdev_free_io(io);
+        }
+
+        let p = Promissory::<()>::from_raw(cx.cast());
+
+        Promissory::set_result(p, if_else!(success, Ok(()), Err(EIO)));
     }
 
     /// Executes an I/O operation, queuing the I/O for later execution if there
@@ -143,7 +162,7 @@ impl IoChannel {
         F: FnMut(&mut Rc<Promissory<()>>) -> Poll<Result<(), Errno>>,
     {
         loop {
-            match Promise::new(|p| (start_fn)(p)).await {
+            match Promise::new().request(|p| (start_fn)(p)).await {
                 Ok(()) => return Ok(()),
                 Err(e) if e != ENOMEM => return Err(e),
                 Err(_) => self.wait_io_available().await?,

--- a/spdk/src/block/owned.rs
+++ b/spdk/src/block/owned.rs
@@ -7,7 +7,7 @@ use spdk_sys::spdk_bdev;
 use crate::{block::Device, errors::Errno};
 
 /// A trait for owned block devices.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait OwnedOps: From<Owned> + Send + 'static {
     /// Returns a pointer to the underlying `spdk_bdev` structure.
     fn as_ptr(&self) -> *mut spdk_bdev;
@@ -16,10 +16,10 @@ pub trait OwnedOps: From<Owned> + Send + 'static {
     async fn destroy(self) -> Result<(), Errno>;
 }
 
-type DestroyFn = fn(Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>> + Send>>;
+type DestroyFn = fn(Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>>>>;
 
 /// Destroys the type-erased device managed by the specified [`Owned`] instance.
-fn destroy_device<T>(owned: Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>> + Send>>
+fn destroy_device<T>(owned: Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>>>>
 where
     T: OwnedOps,
 {
@@ -66,7 +66,7 @@ impl Owned {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl OwnedOps for Owned {
     fn as_ptr(&self) -> *mut spdk_bdev {
         self.bdev.as_ptr()

--- a/spdk/src/nvmf/subsystem.rs
+++ b/spdk/src/nvmf/subsystem.rs
@@ -195,46 +195,50 @@ impl Subsystem {
     ///
     /// This method transitions of the subsystem from the Inactive to Active state.
     pub async fn start(&self) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = (Self::complete_state_change, Promissory::into_raw(p.clone()));
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) =
+                    (Self::complete_state_change, Promissory::into_raw(p.clone()));
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_nvmf_subsystem_start(
-                        self.as_ptr(),
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_nvmf_subsystem_start(
+                            self.as_ptr(),
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Stops the subsystem.
     ///
     /// This method transitions of the subsystem from the Active to Inactive state.
     pub async fn stop(&self) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = (Self::complete_state_change, Promissory::into_raw(p.clone()));
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) =
+                    (Self::complete_state_change, Promissory::into_raw(p.clone()));
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                        spdk_nvmf_subsystem_stop(
-                        self.as_ptr(),
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                            spdk_nvmf_subsystem_stop(
+                            self.as_ptr(),
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Pauses the subsystem.
@@ -247,47 +251,51 @@ impl Subsystem {
     /// subsystem is resumed. A namespace identifier of 0 indicates that no
     /// namespace is paused while `SPDK_NVME_GLOBAL_NS_TAG` pauses all namespaces.
     pub async fn pause(&self, ns: u32) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = (Self::complete_state_change, Promissory::into_raw(p.clone()));
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) =
+                    (Self::complete_state_change, Promissory::into_raw(p.clone()));
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_nvmf_subsystem_pause(
-                        self.as_ptr(),
-                        ns,
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_nvmf_subsystem_pause(
+                            self.as_ptr(),
+                            ns,
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Resumes the subsystem.
     ///
     /// This method transitions of the subsystem from the Inactive to Paused state.
     pub async fn resume(&self) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = (Self::complete_state_change, Promissory::into_raw(p.clone()));
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) =
+                    (Self::complete_state_change, Promissory::into_raw(p.clone()));
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_nvmf_subsystem_resume(
-                        self.as_ptr(),
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_nvmf_subsystem_resume(
+                            self.as_ptr(),
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Adds the given block device as a namespace on the subsystem.
@@ -332,21 +340,22 @@ impl Subsystem {
     /// The subsystem must be in the Paused or Inactive states to add a
     /// listener.
     pub async fn add_listener(&self, transport_id: &TransportId) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-            unsafe {
-                spdk_nvmf_subsystem_add_listener(
-                    self.as_ptr(),
-                    transport_id.as_ptr() as *mut _,
-                    Some(cb_fn),
-                    cb_arg.cast_mut() as *mut _,
-                );
-            }
+                unsafe {
+                    spdk_nvmf_subsystem_add_listener(
+                        self.as_ptr(),
+                        transport_id.as_ptr() as *mut _,
+                        Some(cb_fn),
+                        cb_arg.cast_mut() as *mut _,
+                    );
+                }
 
-            Poll::Pending
-        })
-        .await
+                Poll::Pending
+            })
+            .await
     }
 
     /// Removes a listener on the specified transport from the subsystem.

--- a/spdk/src/nvmf/target.rs
+++ b/spdk/src/nvmf/target.rs
@@ -196,22 +196,23 @@ impl Target {
     pub async fn destroy(mut self) -> Result<(), Errno> {
         match self.0 {
             OwnershipState::Owned(_) => {
-                Promise::new(move |p| {
-                    let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+                Promise::new()
+                    .request(move |p| {
+                        let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-                    unsafe {
-                        spdk_nvmf_tgt_destroy(
-                            self.as_ptr(),
-                            Some(cb_fn),
-                            cb_arg.cast_mut() as *mut _,
-                        );
-                    }
+                        unsafe {
+                            spdk_nvmf_tgt_destroy(
+                                self.as_ptr(),
+                                Some(cb_fn),
+                                cb_arg.cast_mut() as *mut _,
+                            );
+                        }
 
-                    mem::forget(self.take());
+                        mem::forget(self.take());
 
-                    Poll::Pending
-                })
-                .await
+                        Poll::Pending
+                    })
+                    .await
             }
             OwnershipState::Borrowed(_) => Err(EPERM),
             OwnershipState::None => Err(EBADF),
@@ -220,21 +221,22 @@ impl Target {
 
     /// Adds a transport to the target.
     pub async fn add_transport(&mut self, transport: Transport) -> Result<(), Errno> {
-        let res = Promise::new(|p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
+        let res = Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
-            unsafe {
-                spdk_nvmf_tgt_add_transport(
-                    self.as_ptr(),
-                    transport.as_ptr(),
-                    Some(cb_fn),
-                    cb_arg.cast_mut() as *mut _,
-                );
-            }
+                unsafe {
+                    spdk_nvmf_tgt_add_transport(
+                        self.as_ptr(),
+                        transport.as_ptr(),
+                        Some(cb_fn),
+                        cb_arg.cast_mut() as *mut _,
+                    );
+                }
 
-            Poll::Pending
-        })
-        .await;
+                Poll::Pending
+            })
+            .await;
 
         match res {
             Ok(()) => {
@@ -298,24 +300,25 @@ impl Target {
 
     /// Removes a subsystem from the target.
     pub async fn remove_subsystem(&mut self, subsys: Subsystem) -> Result<(), Errno> {
-        Promise::new(|p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
+        Promise::new()
+            .request(|p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
 
-            to_poll_pending_on_err! {
-                EINPROGRESS,
-                unsafe {
-                    spdk_nvmf_subsystem_destroy(
-                        subsys.as_ptr(),
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _,
-                    )
+                to_poll_pending_on_err! {
+                    EINPROGRESS,
+                    unsafe {
+                        spdk_nvmf_subsystem_destroy(
+                            subsys.as_ptr(),
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _,
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Returns an iterator over the subsystems on this target.

--- a/spdk/src/nvmf/transport.rs
+++ b/spdk/src/nvmf/transport.rs
@@ -123,24 +123,25 @@ impl Builder {
 
     /// Creates the configured `Transport`.
     pub async fn build(self) -> Result<Transport, Errno> {
-        Promise::new(move |p| {
-            let (cb_fn, cb_arg) = Promissory::callback_with_object(p);
+        Promise::new()
+            .request(move |p| {
+                let (cb_fn, cb_arg) = Promissory::callback_with_object(p);
 
-            to_poll_pending_on_ok! {
-                unsafe {
-                    spdk_nvmf_transport_create_async(
-                        self.transport_name.as_ptr(),
-                        self.opts.as_ref() as *const _ as *mut _,
-                        Some(cb_fn),
-                        cb_arg.cast_mut() as *mut _,
-                    )
+                to_poll_pending_on_ok! {
+                    unsafe {
+                        spdk_nvmf_transport_create_async(
+                            self.transport_name.as_ptr(),
+                            self.opts.as_ref() as *const _ as *mut _,
+                            Some(cb_fn),
+                            cb_arg.cast_mut() as *mut _,
+                        )
+                    }
+                    => on ready {
+                        unsafe { drop(Promissory::from_raw(cb_arg)) };
+                    }
                 }
-                => on ready {
-                    unsafe { drop(Promissory::from_raw(cb_arg)) };
-                }
-            }
-        })
-        .await
+            })
+            .await
     }
 
     /// Sets the maximum queue depth.
@@ -351,27 +352,28 @@ impl Transport {
             OwnershipState::Borrowed(_) => Err(EPERM),
             OwnershipState::None => Err(ENODEV),
             OwnershipState::Owned(_) => {
-                Promise::new(move |p| {
-                    let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
+                Promise::new()
+                    .request(move |p| {
+                        let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
 
-                    let res = to_poll_pending_on_ok! {
-                        unsafe {
-                            spdk_nvmf_transport_destroy(
-                                self.as_ptr(),
-                                Some(cb_fn),
-                                cb_arg.cast_mut() as *mut _,
-                            )
-                        }
-                        => on ready {
-                            unsafe { drop(Promissory::from_raw(cb_arg)) };
-                        }
-                    };
+                        let res = to_poll_pending_on_ok! {
+                            unsafe {
+                                spdk_nvmf_transport_destroy(
+                                    self.as_ptr(),
+                                    Some(cb_fn),
+                                    cb_arg.cast_mut() as *mut _,
+                                )
+                            }
+                            => on ready {
+                                unsafe { drop(Promissory::from_raw(cb_arg)) };
+                            }
+                        };
 
-                    mem::forget(self.take());
+                        mem::forget(self.take());
 
-                    res
-                })
-                .await
+                        res
+                    })
+                    .await
             }
         }
     }

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -1,11 +1,10 @@
 #![allow(dead_code)]
 use std::{
-    cell::RefCell,
+    cell::{RefCell, UnsafeCell},
     fmt::Debug,
-    mem::{self, MaybeUninit},
+    mem::{self, transmute, MaybeUninit},
     pin::Pin,
-    ptr::addr_of_mut,
-    rc::Rc,
+    rc::{Rc, Weak},
     task::{Context, Poll, Waker},
 };
 
@@ -25,7 +24,7 @@ use crate::{
 ///
 /// ```mermaid
 /// stateDiagram-v2
-/// Empty --> Requesting : poll(cx)
+/// Empty --> Requesting : request(start_fn)
 /// Requesting --> Waiting : poll(cx)
 /// Requesting --> Kept : set_result(res) | Ready(res)
 /// Waiting --> Waiting : poll(cx)
@@ -43,32 +42,29 @@ where
 
     /// The promisee is requesting a promise.
     ///
-    /// This state indicates the promise is invoking the function to start the
-    /// asynchronous operation.
+    /// This state indicates the promise is invoking the function to start the asynchronous
+    /// operation.
     Requesting,
 
     /// The promisee is waiting for the promise to be kept.
     ///
-    /// This state occurs when the start function returns `Poll::Pending` and
-    /// before a completion callback is invoked.
+    /// This state occurs when the start function returns `Poll::Pending` and before a completion
+    /// callback is invoked.
     Waiting(Waker),
 
     /// The promisor has kept the promise and delivered a result.
     ///
-    /// This state occurs either when the start function returns
-    /// `Poll::Ready(res)` or when the asynchrounous operation invokes a
-    /// completion callback.
+    /// This state occurs either when the start function returns `Poll::Ready(res)` or when the
+    /// asynchrounous operation invokes a completion callback.
     ///
-    /// If a completion function is invoked before the start function returns,
-    /// the promise transitions from the `Requesting` state to the `Kept` state
-    /// directly. Otherwise, the promise transitions from the `Requesting` state
-    /// to the `Waiting` state.
+    /// If a completion function is invoked before the start function returns, the promise
+    /// transitions from the `Requesting` state to the `Kept` state directly. Otherwise, the promise
+    /// transitions from the `Requesting` state to the `Waiting` state.
     Kept(Result<T, Errno>),
 
     /// The promisee has received the promised result.
     ///
-    /// This state occurs when the result has been returned to the promise's
-    /// caller.
+    /// This state occurs when the result has been returned to the promise's caller.
     Fulfilled,
 }
 
@@ -78,19 +74,33 @@ impl<T> PromiseState<T>
 where
     T: Debug + 'static,
 {
-    /// Replaces the current state with the specified value and returns the old state.
-    fn replace(&mut self, value: Self) -> Self {
-        mem::replace(&mut *self, value)
-    }
-
     /// Polls the state of the operation, advancing to the next state if possible.
     fn poll(&mut self, cx: &Context<'_>) -> Self {
         match self {
-            Self::Empty => self.replace(Self::Requesting),
-            Self::Requesting => self.replace(Self::Waiting(cx.waker().clone())),
+            Self::Requesting => mem::replace(self, Self::Waiting(cx.waker().clone())),
             Self::Waiting(waker) => Self::Waiting(waker.clone()),
-            Self::Kept(_) => self.replace(Self::Fulfilled),
+            Self::Kept(_) => mem::replace(self, Self::Fulfilled),
             _ => panic!("promise polled in unexpected state: {:?}", self),
+        }
+    }
+
+    /// Sets the state of the operation to [`Requesting`].
+    ///
+    /// [`Requesting`]: Self::Requesting
+    fn set_requesting(&mut self) {
+        match self {
+            PromiseState::Empty => *self = Self::Requesting,
+            _ => panic!("set_requesting called in unexpected state: {:?}", self),
+        }
+    }
+
+    /// Sets the state and result of the operation to [`Kept`].
+    ///
+    /// [`Kept`]: Self::Kept
+    fn set_kept(&mut self, res: Result<T, Errno>) -> Self {
+        match self {
+            Self::Requesting | Self::Waiting(_) => mem::replace(self, Self::Kept(res)),
+            _ => panic!("set_kept called in unexpected state: {:?}", self),
         }
     }
 }
@@ -99,7 +109,8 @@ where
 ///
 /// <div class="warning">
 ///
-/// The `Promissory` type is not thread-safe. It must be used on the same SPDK thread that created it.
+/// The `Promissory` type is not thread-safe. It must be used on the same SPDK thread that created
+/// it.
 ///
 /// </div>
 pub struct Promissory<R, C = ()>
@@ -115,7 +126,7 @@ where
 impl<R, C> Promissory<R, C>
 where
     R: Debug + 'static,
-    C: 'static,
+    C: Unpin + 'static,
 {
     /// Returns a new `Rc<Promise>` instance with the provided context.
     pub fn with_context(ctx: C) -> Rc<Self> {
@@ -126,46 +137,82 @@ where
         })
     }
 
-    /// Returns a new `Rc<Promise>` instance, initializing the context in-place
-    /// using the specified function.
-    pub fn with_context_in_place<F>(ctx_init_fn: F) -> Rc<Self>
+    /// Constructs a new `Rc<Promissory>` instance giving you a `Weak<Promissory>` to the allocation
+    /// allowing you to construct the context, C, holding a weak pointer to itself.
+    ///
+    /// See [`Rc::new_cyclic`] for more information on cyclic reference counting strategies.
+    pub fn with_context_cyclic<F>(data_fn: F) -> Rc<Self>
     where
-        F: FnOnce(*mut C),
+        F: FnOnce(&Weak<Self>) -> C,
     {
-        let rc_ctx = Rc::new(MaybeUninit::<Self>::uninit());
+        Rc::new_cyclic(|weak_self| Self {
+            state: Default::default(),
+            thread: Thread::current(),
+            ctx: data_fn(weak_self),
+        })
+    }
+}
 
-        unsafe {
-            let ctx = (*(Rc::into_raw(rc_ctx) as *mut MaybeUninit<Self>)).as_mut_ptr();
+impl<R, C> Promissory<R, C>
+where
+    R: Debug + 'static,
+    C: 'static,
+{
+    /// Constructs a new `Rc<Promissory>` instance initializing the context, `C` in place. This
+    /// function also provides a `Weak<Promissory>` to the allocation allowing you to initialize the
+    /// context holding a weak pointer to itself.
+    ///
+    /// See [`Rc::new_cyclic`] for more information on cyclic reference counting strategies.
+    ///
+    /// # Safety
+    ///
+    /// The initialization function, `init_fn`, must ensure that it initializes the context through
+    /// the reference and does not access or mutate it by through the weak pointer.
+    pub fn with_context_cyclic_in_place<I>(init_fn: I) -> Rc<Self>
+    where
+        I: FnOnce(Pin<&mut MaybeUninit<C>>, &Weak<Promissory<R, MaybeUninit<C>>>),
+    {
+        let this = Rc::new(Promissory::<R, _> {
+            state: Default::default(),
+            thread: Thread::current(),
+            ctx: UnsafeCell::new(MaybeUninit::zeroed()),
+        });
 
-            addr_of_mut!((*ctx).state).write(Default::default());
-            addr_of_mut!((*ctx).thread).write(Thread::current());
-            ctx_init_fn(addr_of_mut!((*ctx).ctx));
+        // SAFETY: The promissory has been initialized except its context.
+        let weak: Weak<Promissory<R, MaybeUninit<C>>> = unsafe { transmute(Rc::downgrade(&this)) };
 
-            Rc::from_raw(ctx)
-        }
+        // SAFETY: The initialization function must ensure that it initializes the context through
+        // the reference and does not access or mutate it through the weak pointer.
+        init_fn(unsafe { Pin::new_unchecked(&mut *this.ctx.get()) }, &weak);
+
+        // SAFETY: The promissory has been completely initialized at this point.
+        unsafe { transmute(this) }
     }
 
     /// Polls the state of the operation, advancing to the next state if possible.
-    fn poll(&self, cx: &Context<'_>) -> PromiseState<R> {
+    fn poll_state(&self, cx: &Context<'_>) -> PromiseState<R> {
         self.state.borrow_mut().poll(cx)
     }
 
-    /// Returns a reference to the user context initialized using either the
-    /// [`Promise::with_context`] or [`Promise::with_context_in_place`]
-    /// functions.
+    /// Sets the state of the operation to [`PromiseState::Requesting`].
+    fn set_requesting(&self) {
+        self.state.borrow_mut().set_requesting();
+    }
+
+    /// Sets the state and result of the operation to [`PromiseState::Kept`].
+    fn set_kept(&self, res: Result<R, Errno>) -> PromiseState<R> {
+        self.state.borrow_mut().set_kept(res)
+    }
+
+    /// Returns a reference to the user context.
     pub fn user_context(rc_self: &Rc<Self>) -> &C {
         &rc_self.ctx
     }
 
-    /// Returns a mutable reference to the user context if there are no other
-    /// `Rc` or `Weak` pointers to the same allocation.
+    /// Returns a mutable reference to the user context if there are no other `Rc` or `Weak`
+    /// pointers to the same allocation.
     ///
-    /// Returns [`None`] otherwise because it is not safe to mutate the context
-    /// of a shared valued.
-    ///
-    /// The user context is initialized using either the
-    /// [`Promise::with_context`] or [`Promise::with_context_in_place`]
-    /// functions.
+    /// Returns [`None`] otherwise because it is not safe to mutate the context of a shared valued.
     pub fn user_context_mut(rc_self: &mut Rc<Self>) -> Option<&mut C> {
         Rc::get_mut(rc_self).map(|p| &mut p.ctx)
     }
@@ -176,8 +223,9 @@ where
             rc_self.thread.is_current(),
             "set_result called from wrong thread"
         );
+
         let prev_state = match rc_self.state.try_borrow_mut() {
-            Ok(mut state) => Ok(state.replace(PromiseState::Kept(res))),
+            Ok(mut state) => Ok(state.set_kept(res)),
             Err(_) => Err(res),
         };
 
@@ -199,9 +247,9 @@ where
 
     /// A callback invoked to set the result of a [`Promise`].
     ///
-    /// This callback receives a raw pointer to an SPDK object of type `R` and
-    /// converts it to the appropriate Rust type `T`. If the received pointer is
-    /// null, the result is a suitable `Err(Errno)` value.
+    /// This callback receives a raw pointer to an SPDK object of type `R` and converts it to the
+    /// appropriate Rust type `T`. If the received pointer is null, the result is a suitable
+    /// `Err(Errno)` value.
     unsafe extern "C" fn complete_with_object<T>(cx: *mut c_void, obj: *mut T)
     where
         R: Debug + TryFrom<*mut T, Error = Errno> + 'static,
@@ -212,13 +260,12 @@ where
         Self::set_result(rc_self, obj.try_into().map_err(|_| EINVAL));
     }
 
-    /// Returns a pointer to a callback function and a context pointer suitable
-    /// for passing to an asynchronous function call. The callback is invoked to
-    /// set the result of a [`Promise`].
+    /// Returns a pointer to a callback function and a context pointer suitable for passing to an
+    /// asynchronous function call. The callback is invoked to set the result of a [`Promise`].
     ///
-    /// This callback receives a raw pointer to an SPDK object of type `R` and
-    /// converts it to the appropriate Rust type `T`. If the received pointer is
-    /// null, the result is a suitable `Err(Errno)` value.
+    /// This callback receives a raw pointer to an SPDK object of type `R` and converts it to the
+    /// appropriate Rust type `T`. If the received pointer is null, the result is a suitable
+    /// `Err(Errno)` value.
     pub fn callback_with_object<T>(
         rc_self: &Rc<Self>,
     ) -> (unsafe extern "C" fn(*mut c_void, *mut T), *const Self)
@@ -230,16 +277,16 @@ where
 
     /// Consumes an `Rc<Promissory>` instance and returns the wrapped pointer.
     ///
-    /// To avoid a memory leak, the pointer must be converted back to an
-    /// `Rc<Promissory>` using the [`Promissory::from_raw`] function.
+    /// To avoid a memory leak, the pointer must be converted back to an `Rc<Promissory>` using the
+    /// [`Promissory::from_raw`] function.
     pub fn into_raw(rc_self: Rc<Self>) -> *const Self {
         Rc::into_raw(rc_self)
     }
 
     /// Constructs an `Rc<Promissory>` instance from a raw pointer.
     ///
-    /// The raw pointer must have been previously returned by a call to
-    /// `Promissory<R, C>::into_raw`.
+    /// The raw pointer must have been previously returned by a call to `Promissory<R,
+    /// C>::into_raw`.
     ///
     /// # Safety
     ///
@@ -259,22 +306,19 @@ where
 impl<C> Promissory<(), C> {
     /// A callback invoked to set the result of a [`Promise`].
     ///
-    /// This callback receives a status code. If the status code is 0, the result is
-    /// `Ok(())`. Otherwise, the status is converted to a suitable `Err(Errno)`
-    /// value.
+    /// This callback receives a status code. If the status code is 0, the result is `Ok(())`.
+    /// Otherwise, the status is converted to a suitable `Err(Errno)` value.
     unsafe extern "C" fn complete_with_status(cx: *mut c_void, status: i32) {
         let rc_self = Self::from_raw(cx.cast());
 
         Self::set_result(rc_self, to_result!(status));
     }
 
-    /// Returns a pointer to a callback function and a context pointer suitable
-    /// for passing to an asynchronous function call. The callback is invoked to
-    /// set the result of a [`Promise`].
+    /// Returns a pointer to a callback function and a context pointer suitable for passing to an
+    /// asynchronous function call. The callback is invoked to set the result of a [`Promise`].
     ///
-    /// This callback receives a status code. If the status code is 0, the result is
-    /// `Ok(())`. Otherwise, the status is converted to a suitable `Err(Errno)`
-    /// value.
+    /// This callback receives a status code. If the status code is 0, the result is `Ok(())`.
+    /// Otherwise, the status is converted to a suitable `Err(Errno)` value.
     pub fn callback_with_status(
         rc_self: &Rc<Self>,
     ) -> (unsafe extern "C" fn(*mut c_void, i32), *const Self) {
@@ -290,9 +334,8 @@ impl<C> Promissory<(), C> {
         Self::set_result(rc_self, Ok(()));
     }
 
-    /// Returns a pointer to a callback function and a context pointer suitable
-    /// for passing to an asynchronous function call. The callback is invoked to
-    /// set the result of a [`Promise`].
+    /// Returns a pointer to a callback function and a context pointer suitable for passing to an
+    /// asynchronous function call. The callback is invoked to set the result of a [`Promise`].
     ///
     /// This callback always sets the result to `Ok(())`.
     pub fn callback_with_ok(
@@ -316,122 +359,148 @@ where
     }
 }
 
-/// A function that starts the asynchronous operation the will yield a result
-/// for the [`Promise`].
-type StartFn<'a, R, C> = dyn FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R, Errno>> + 'a;
-
-/// Orchestrates the execution of an asynchronous operation and provides access
-/// to its result.
-///
-/// <div class="warning">
-///
-/// The `Promise` type is not thread-safe. It must be used on the same SPDK thread that created it.
-///
-/// </div>
-pub struct Promise<'a, R, C = ()>
+/// A future implementation for awaiting the result of a [`Promise`].
+struct FuturePromise<R, C>(Rc<Promissory<R, C>>)
 where
     R: Debug + 'static,
-    C: 'static,
-{
-    start_fn: Option<Box<StartFn<'a, R, C>>>,
-    promissory: Rc<Promissory<R, C>>,
-}
+    C: 'static;
 
-unsafe impl<'a, R, C> Send for Promise<'a, R, C>
-where
-    R: Debug + Send + 'static,
-    C: 'static,
-{
-}
-
-impl<'a, R> Promise<'a, R>
-where
-    R: Debug + 'static,
-{
-    /// Returns a new `Promise` instance.
-    ///
-    /// The caller provides a function that starts the asynchronous operation
-    /// passing one of the `complete_with_*` callbacks and the provided context
-    /// pointer to the SPDK API.
-    pub fn new<S>(start_fn: S) -> Self
-    where
-        S: FnOnce(&mut Rc<Promissory<R>>) -> Poll<Result<R, Errno>> + 'a,
-    {
-        Self {
-            start_fn: Some(Box::new(start_fn)),
-            promissory: Default::default(),
-        }
-    }
-}
-
-impl<'a, R, C> Promise<'a, R, C>
-where
-    R: Debug + 'static,
-    C: 'static,
-{
-    /// Returns a new `Promise` instance the user context of the related
-    /// `Promissory` initialized to the specified value.
-    pub fn with_context<S>(ctx: C, start_fn: S) -> Self
-    where
-        S: FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R, Errno>> + 'a,
-    {
-        Self {
-            start_fn: Some(Box::new(start_fn)),
-            promissory: Promissory::with_context(ctx),
-        }
-    }
-
-    /// Returns a new `Promise` instance with the user context of the related
-    /// `Promissory` initialized in-place using the specified function.
-    ///
-    /// The pointer provided to the initialization function points to
-    /// uninitialized memory. Reading from this pointer is undefined behavior.
-    pub fn with_context_in_place<F, S>(ctx_init_fn: F, start_fn: S) -> Self
-    where
-        S: FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R, Errno>> + 'a,
-        F: FnOnce(*mut C),
-    {
-        Self {
-            start_fn: Some(Box::new(start_fn)),
-            promissory: Promissory::with_context_in_place(ctx_init_fn),
-        }
-    }
-}
-
-impl<'a, R, C> Future for Promise<'a, R, C>
+impl<R, C> Future for FuturePromise<R, C>
 where
     R: Debug + 'static,
     C: 'static,
 {
     type Output = Result<R, Errno>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let state = self.promissory.poll(cx);
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let state = self.0.poll_state(cx);
 
         match state {
-            PromiseState::Empty => {
-                let start_fn = self
-                    .as_mut()
-                    .start_fn
-                    .take()
-                    .expect("called in empty state");
-
-                match (start_fn)(&mut self.promissory) {
-                    Poll::Pending => {
-                        let state = self.promissory.poll(cx);
-
-                        if let PromiseState::Kept(res) = state {
-                            return Poll::Ready(res);
-                        }
-
-                        Poll::Pending
-                    }
-                    Poll::Ready(res) => Poll::Ready(res),
-                }
-            }
-            PromiseState::Waiting(_) => Poll::Pending,
+            PromiseState::Requesting | PromiseState::Waiting(_) => Poll::Pending,
             PromiseState::Kept(res) => Poll::Ready(res),
-            _ => unreachable!("promise already fulfilled"),
+            _ => unreachable!("promise polled in unexpected state: {:?}", state),
         }
+    }
+}
+
+/// Orchestrates the execution of an asynchronous operation and provides access to its result.
+///
+/// <div class="warning">
+///
+/// The `Promise` type is not thread-safe. It must be used on the same SPDK thread that created it.
+///
+/// </div>
+pub struct Promise<R, C = ()>(Rc<Promissory<R, C>>)
+where
+    R: Debug + 'static,
+    C: 'static;
+
+unsafe impl<R, C> Send for Promise<R, C>
+where
+    R: Debug + Send + 'static,
+    C: 'static,
+{
+}
+
+impl<R> Promise<R>
+where
+    R: Debug + 'static,
+{
+    /// Returns a new `Promise` instance.
+    ///
+    /// A newly created `Promise` is empty. You must call the [`request`] method to begin the
+    /// asynchronous operation.
+    ///
+    /// [`request`]: Self::request
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<R> Default for Promise<R>
+where
+    R: Debug + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R, C> Promise<R, C>
+where
+    R: Debug + 'static,
+    C: Unpin + 'static,
+{
+    /// Returns a new `Promise` instance with the user context of the related `Promissory`
+    /// initialized to the specified value.
+    ///
+    /// A newly created `Promise` is empty. You must call the [`request`] method to begin the
+    /// asynchronous operation.
+    ///
+    /// [`request`]: Self::request
+    pub fn with_context(ctx: C) -> Self {
+        Self(Promissory::with_context(ctx))
+    }
+
+    /// Constructs a new `Promise` instance giving you a `Weak<Promissory>` to the related
+    /// `Promissory` allocation allowing you to construct the context, C, holding a weak pointer to
+    /// it.
+    ///
+    /// See [`Rc::new_cyclic`] for more information on cyclic reference counting strategies.
+    ///
+    /// A newly created `Promise` is empty. You must call the [`request`] method to begin the
+    /// asynchronous operation.
+    ///
+    /// [`request`]: Self::request
+    pub fn with_context_cyclic<F>(data_fn: F) -> Self
+    where
+        F: FnOnce(&Weak<Promissory<R, C>>) -> C,
+    {
+        Self(Promissory::with_context_cyclic(data_fn))
+    }
+}
+
+impl<R, C> Promise<R, C>
+where
+    R: Debug + 'static,
+    C: 'static,
+{
+    /// Constructs a new `Promise` instance initializing the context, `C`, in place in the related
+    /// `Promissory` allocation. This function also provides a `Weak<Promissory>` to the allocation
+    /// allowing you to initialize the context holding a weak pointer to itself.
+    ///
+    /// See [`Rc::new_cyclic`] for more information on cyclic reference counting strategies.
+    ///
+    /// A newly created `Promise` is empty. You must call the [`request`] method to begin the
+    /// asynchronous operation.
+    ///
+    /// # Safety
+    ///
+    /// The initialization function, `init_fn`, must ensure that it initializes the context through
+    /// the reference and does not access or mutate it by through the weak pointer.
+    ///
+    /// [`request`]: Self::request
+    pub fn with_context_cyclic_in_place<I>(init_fn: I) -> Self
+    where
+        I: FnOnce(Pin<&mut MaybeUninit<C>>, &Weak<Promissory<R, MaybeUninit<C>>>),
+    {
+        Self(Promissory::with_context_cyclic_in_place(init_fn))
+    }
+
+    /// Begins the asynchronous operation to fulfill the promise.
+    pub fn request<S>(mut self, start_fn: S) -> impl Future<Output = Result<R, Errno>>
+    where
+        S: FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R, Errno>>,
+    {
+        self.0.set_requesting();
+
+        match (start_fn)(&mut self.0) {
+            Poll::Pending => (),
+            Poll::Ready(res) => {
+                assert!(matches!(self.0.set_kept(res), PromiseState::Requesting))
+            }
+        }
+
+        FuturePromise(self.0)
     }
 }

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -345,7 +345,7 @@ impl Drop for Thread {
             // `spdk_thread` object until the sent message calls `spdk_thread_exit`.
             let mut t = self.borrow();
 
-            // SAFTEY: The `spdk_thread_exit` function must be called from a
+            // SAFETY: The `spdk_thread_exit` function must be called from a
             // poller or thread message. We dispatch the call via thread message
             // to ensure this invariant is satisfied.
             self.send_msg(move || unsafe { _ = spdk_thread_exit(t.as_mut_ptr()) })
@@ -387,8 +387,8 @@ where
 /// associated with other threads, otherwise a deadlock will occur.
 pub fn block_on<F, T>(fut: F) -> T
 where
-    F: Future<Output = T> + Send + 'static,
-    T: Send + 'static,
+    F: Future<Output = T> + 'static,
+    T: 'static,
 {
     let current_thread = Thread::current();
     let mut join_handle = task::spawn_on_current_thread(fut);


### PR DESCRIPTION
Moves the specification of the `Promise`'s start function from the constructor functions to a separate `request` function which invokes the function directly. This avoids the need for a new, separate allocation to store the function for execution on the first `poll` call.

This change also adds a `with_context_cyclic_in_place` constructor function to enable initializing the user context in-place. This is useful for types that cannot be moved, e.g. contain self-references.