### PR TITLE
fix: enforces single ownership and adds lifetime markers for async ops

### DIFF
--- a/spdk/examples/bdev_hello_world.rs
+++ b/spdk/examples/bdev_hello_world.rs
@@ -30,7 +30,7 @@ async fn main() {
     let desc = malloc.open(true).await.unwrap();
 
     thread::spawn_local(async move {
-        let io_chan = desc.io_channel().unwrap();
+        let mut io_chan = desc.io_channel().unwrap();
         let layout = desc.device().layout_for_blocks(1).unwrap();
         let mut buf = dma::Buffer::new_zeroed(layout);
 

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -110,7 +110,7 @@ impl EchoChannel {
 impl BDevIoChannelOps for EchoChannel {
     type IoContext = ();
 
-    async fn submit_request(&self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
         match io.io_type() {
             IoType::Read => self.do_read(io).await,
             IoType::Write => self.do_write(io).await,
@@ -184,7 +184,7 @@ async fn main() {
     let write_thread = Thread::new(c"write", &reactors[0].core().into()).unwrap();
     let write_task = write_thread.spawn(move || async move {
         let writer = echo_writer.open(true).await.unwrap();
-        let writer_ch = writer.io_channel().unwrap();
+        let mut writer_ch = writer.io_channel().unwrap();
         let layout = writer.device().layout_for_blocks(1).unwrap();
         let mut buf = dma::Buffer::new_zeroed(layout);
 
@@ -204,7 +204,7 @@ async fn main() {
     let read_thread = Thread::new(c"read", &reactors[1].core().into()).unwrap();
     let read_task = read_thread.spawn(move || async move {
         let reader = echo_reader.open(true).await.unwrap();
-        let reader_ch = reader.io_channel().unwrap();
+        let mut reader_ch = reader.io_channel().unwrap();
         let layout = reader.device().layout_for_blocks(1).unwrap();
         let mut buf = dma::Buffer::new_zeroed(layout);
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -26,7 +26,7 @@ struct NullRsChannel;
 impl BDevIoChannelOps for NullRsChannel {
     type IoContext = ();
 
-    async fn submit_request(&self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
         if io.io_type() == IoType::Read {
             let dst = io.buffers_mut();
 
@@ -80,7 +80,7 @@ impl BDevOps for NullRs {
 async fn main() {
     let null = NullRs::try_new().unwrap();
     let desc = null.open(true).await.unwrap();
-    let ch = desc.io_channel().unwrap();
+    let mut ch = desc.io_channel().unwrap();
     let layout = null.layout_for_blocks(1).unwrap();
     let mut buf = dma::Buffer::new_zeroed(layout);
 

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -30,7 +30,7 @@ struct PassthruRsChannel {
 impl BDevIoChannelOps for PassthruRsChannel {
     type IoContext = ();
 
-    async fn submit_request(&self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
         match io.io_type() {
             IoType::Read => {
                 let num_blocks = io.num_blocks();
@@ -157,7 +157,7 @@ async fn main() {
     let devname = passthru.name().to_string_lossy().to_string();
 
     thread::spawn_local(async move {
-        let io_chan = passthru_desc.io_channel().unwrap();
+        let mut io_chan = passthru_desc.io_channel().unwrap();
         let layout = passthru_desc.device().layout_for_blocks(1).unwrap();
         let mut buf = dma::Buffer::new_zeroed(layout);
 

--- a/spdk/examples/nvmf.rs
+++ b/spdk/examples/nvmf.rs
@@ -53,7 +53,7 @@ async fn main() {
 
     target.listen(&transport_id).unwrap();
 
-    let subsys = target.add_subsystem(NQN, SubsystemType::NVMe, 1).unwrap();
+    let mut subsys = target.add_subsystem(NQN, SubsystemType::NVMe, 1).unwrap();
 
     let malloc = malloc::Builder::new()
         .with_name(BDEV_NAME)

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -117,7 +117,7 @@ pub trait BDevIoChannelOps: 'static {
     type IoContext: Default + 'static;
 
     /// Submit an I/O request to the BDev.
-    async fn submit_request(&self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno>;
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno>;
 }
 
 /// A BDev I/O channel implementation.
@@ -603,11 +603,11 @@ where
 
     /// Submits an I/O request to the BDev.
     unsafe extern "C" fn submit_request(io_channel: *mut spdk_io_channel, io: *mut spdk_bdev_io) {
-        let io_channel = BDevIoChannel::<T::IoChannel>::from_raw(io_channel);
+        let mut io_channel = BDevIoChannel::<T::IoChannel>::from_raw(io_channel);
         let mut io = BDevIo::new(io);
 
         thread::spawn_local(async move {
-            let res = io_channel.ctx().submit_request(&mut io).await;
+            let res = io_channel.ctx_mut().submit_request(&mut io).await;
 
             io.complete(res.into());
         });

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -5,7 +5,7 @@ use std::{
     mem::{self, offset_of, size_of, ManuallyDrop},
     os::raw::{c_int, c_void},
     ptr::{self, addr_of, addr_of_mut, drop_in_place, NonNull},
-    rc::Rc,
+    rc::{Rc, Weak},
     slice,
     task::Poll,
 };
@@ -185,15 +185,19 @@ where
     }
 }
 
+/// A type alias for the promissory that receives the buffer allocation from a call to the
+/// [`BDevIo<T>::allocate_buffers`] method.
+type AllocateBuffersPromissory<'a, T> = Promissory<(), PhantomData<&'a mut BDevIo<T>>>;
+
 /// Represents driver-specific context for an I/O request.
 ///
 /// The type parameter `T` is the I/O context type for the BDev implementation.
 #[derive(Default)]
-struct BDevIoCtx<T>
+struct BDevIoCtx<'a, T>
 where
     T: Default + 'static,
 {
-    buf_promissory: Option<Rc<Promissory<()>>>,
+    buf_promissory: Option<Weak<AllocateBuffersPromissory<'a, T>>>,
     inner: T,
 }
 
@@ -297,13 +301,13 @@ where
 
     /// Returns a reference to the internal context associated with the I/O
     /// request.
-    fn internal_ctx(&self) -> &BDevIoCtx<T> {
+    fn internal_ctx(&self) -> &BDevIoCtx<'_, T> {
         unsafe { &*self.io.as_ref().driver_ctx.as_ptr().cast() }
     }
 
     /// Returns a mutable reference to the internal context associated with the
     /// I/O request.
-    fn internal_ctx_mut(&mut self) -> &mut BDevIoCtx<T> {
+    fn internal_ctx_mut(&mut self) -> &mut BDevIoCtx<'_, T> {
         unsafe { &mut *self.io.as_mut().driver_ctx.as_mut_ptr().cast() }
     }
 
@@ -333,7 +337,9 @@ where
             .internal_ctx_mut()
             .buf_promissory
             .take()
-            .expect("promissory present");
+            .expect("promissory present")
+            .upgrade()
+            .expect("promissory has strong references");
 
         Promissory::set_result(p, if_else!(success, Ok(()), Err(EINVAL)));
     }
@@ -351,10 +357,12 @@ where
     ///
     /// Any buffers allocated by this method will automatically be freed on
     /// completion of this I/O request.
-    pub async fn allocate_buffers(&mut self, length: u64) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn allocate_buffers<'a>(&'a mut self, length: u64) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(move |p| {
-                self.internal_ctx_mut().buf_promissory.replace(p.clone());
+                self.internal_ctx_mut()
+                    .buf_promissory
+                    .replace(Rc::downgrade(p));
 
                 unsafe {
                     spdk_bdev_io_get_buf(self.as_ptr(), Some(Self::buffers_allocated), length)

--- a/spdk/src/block/io_channel.rs
+++ b/spdk/src/block/io_channel.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Debug, Formatter},
     io::{IoSlice, IoSliceMut},
+    marker::PhantomData,
     mem,
     os::raw::c_void,
     ptr::{addr_of, addr_of_mut, NonNull},
@@ -31,22 +32,22 @@ use super::{Any, Descriptor, Device};
 
 /// A wrapper around [`spdk_bdev_io_wait_entry`] that manages ownership of a weak pointer to the
 /// [`Promissory`] instance awaiting availability of an [`spdk_bdev_io`] structure.
-struct IoWait(spdk_bdev_io_wait_entry);
+struct IoWait<'a>(spdk_bdev_io_wait_entry, PhantomData<&'a mut IoChannel>);
 
-impl IoWait {
+impl<'a> IoWait<'a> {
     /// Creates a new instance of an `IoWait` structure.
-    fn new(p: &Weak<Promissory<(), IoWait>>, channel: &IoChannel) -> Self {
+    fn new(p: &Weak<Promissory<(), IoWait>>, channel: &'a mut IoChannel) -> Self {
         let mut wait: spdk_bdev_io_wait_entry = unsafe { mem::zeroed() };
 
         wait.bdev = channel.bdev();
         wait.cb_fn = Some(IoChannel::wait_io_complete);
         wait.cb_arg = p.clone().into_raw() as *mut _;
 
-        Self(wait)
+        Self(wait, PhantomData)
     }
 }
 
-impl Drop for IoWait {
+impl Drop for IoWait<'_> {
     fn drop(&mut self) {
         drop(unsafe {
             Rc::from_raw(self.0.cb_arg as *const Promissory<(), spdk_bdev_io_wait_entry>)
@@ -127,6 +128,8 @@ impl IoChannel {
     /// This function returns `Err(EINVAL)` if the I/O channel an I/O buffer is
     /// available on the current thread..
     async fn wait_io_available(&mut self) -> Result<(), Errno> {
+        let ch = self.channel;
+
         Promise::with_context_cyclic(|w| IoWait::new(w, self))
             .request(|p| {
                 let wait: &IoWait = Promissory::user_context(p);
@@ -134,8 +137,8 @@ impl IoChannel {
                 to_poll_pending_on_ok! {
                     unsafe {
                         spdk_bdev_queue_io_wait(
-                            self.bdev(),
-                            self.channel.as_ptr(),
+                            wait.0.bdev,
+                            ch.as_ptr(),
                             &wait.0 as *const _ as *mut _
                         )
                     }
@@ -157,12 +160,16 @@ impl IoChannel {
 
     /// Executes an I/O operation, queuing the I/O for later execution if there
     /// are no `spdk_bdev_io` structures available.
-    async fn execute_io<F>(&mut self, mut start_fn: F) -> Result<(), Errno>
+    async fn execute_io<F, T>(&mut self, data: PhantomData<T>, mut start_fn: F) -> Result<(), Errno>
     where
-        F: FnMut(&mut Self, &mut Rc<Promissory<()>>) -> Poll<Result<(), Errno>>,
+        F: FnMut(&mut Self, &mut Rc<Promissory<(), PhantomData<T>>>) -> Poll<Result<(), Errno>>,
+        T: Unpin,
     {
         loop {
-            match Promise::new().request(|p| (start_fn)(self, p)).await {
+            match Promise::with_context(data)
+                .request(|p| (start_fn)(self, p))
+                .await
+            {
                 Ok(()) => return Ok(()),
                 Err(e) if e != ENOMEM => return Err(e),
                 Err(_) => self.wait_io_available().await?,
@@ -171,8 +178,8 @@ impl IoChannel {
     }
 
     /// Resets the block device zone.
-    pub async fn reset_zone(&mut self, zone_id: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn reset_zone<'a>(&'a mut self, zone_id: u64) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -196,8 +203,12 @@ impl IoChannel {
 
     /// Writes the data in the buffer to the block device at the specified
     /// byte offset.
-    pub async fn write_at<B: AsRef<[u8]>>(&mut self, buf: &B, offset: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn write_at<'a, B: AsRef<[u8]>>(
+        &'a mut self,
+        buf: &'a B,
+        offset: u64,
+    ) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let buf = buf.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -223,16 +234,16 @@ impl IoChannel {
 
     /// Writes the data in the slice of buffers to the block device at the specified
     /// byte offset.
-    pub async fn write_vectored_at<'b, B>(
-        &mut self,
-        bufs: &'b B,
+    pub async fn write_vectored_at<'a, B>(
+        &'a mut self,
+        bufs: &'a B,
         offset: u64,
         length: u64,
     ) -> Result<(), Errno>
     where
-        B: AsRef<[IoSlice<'b>]> + ?Sized,
+        B: AsRef<[IoSlice<'a>]> + ?Sized,
     {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let bufs = bufs.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -261,12 +272,12 @@ impl IoChannel {
     /// block offset.
     ///
     /// The buffer length must be a multiple of the block size of the device.
-    pub async fn write_blocks_at<B: AsRef<[u8]>>(
-        &mut self,
-        buf: &B,
+    pub async fn write_blocks_at<'a, B: AsRef<[u8]>>(
+        &'a mut self,
+        buf: &'a B,
         offset_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let buf = buf.as_ref();
             let logical_block_size = this.device().logical_block_size() as usize;
 
@@ -298,16 +309,16 @@ impl IoChannel {
 
     /// Writes the data in the slice of buffers to the block device at the specified
     /// block offset.
-    pub async fn write_vectored_blocks_at<'b, B>(
-        &mut self,
-        bufs: &'b B,
+    pub async fn write_vectored_blocks_at<'a, B>(
+        &'a mut self,
+        bufs: &'a B,
         offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno>
     where
-        B: AsRef<[IoSlice<'b>]> + ?Sized,
+        B: AsRef<[IoSlice<'a>]> + ?Sized,
     {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let bufs = bufs.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -333,8 +344,8 @@ impl IoChannel {
     }
 
     /// Writes zeroes to the block device at the specified byte offset.
-    pub async fn write_zeroes_at(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn write_zeroes_at<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -357,12 +368,12 @@ impl IoChannel {
     }
 
     /// Writes zeroes to the block device at the specified block offset.
-    pub async fn write_zeroes_blocks_at(
-        &mut self,
+    pub async fn write_zeroes_blocks_at<'a>(
+        &'a mut self,
         offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -386,8 +397,12 @@ impl IoChannel {
 
     /// Reads data from the block device at the specified byte offset into the
     /// buffer.
-    pub async fn read_at<B: AsMut<[u8]>>(&mut self, buf: &mut B, offset: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn read_at<'a, B: AsMut<[u8]>>(
+        &'a mut self,
+        buf: &'a mut B,
+        offset: u64,
+    ) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -412,16 +427,16 @@ impl IoChannel {
 
     /// Reads data from the block device at the specified byte offset into the
     /// slice of buffers.
-    pub async fn read_vectored_at<'b, B>(
-        &mut self,
-        bufs: &'b mut B,
+    pub async fn read_vectored_at<'a, B>(
+        &'a mut self,
+        bufs: &'a mut B,
         offset: u64,
         length: u64,
     ) -> Result<(), Errno>
     where
-        B: AsMut<[IoSliceMut<'b>]> + ?Sized,
+        B: AsMut<[IoSliceMut<'a>]> + ?Sized,
     {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let bufs = bufs.as_mut();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -450,12 +465,12 @@ impl IoChannel {
     /// buffer.
     ///
     /// The buffer must be a multiple of the block size of the device.
-    pub async fn read_blocks_at<B: AsMut<[u8]>>(
-        &mut self,
-        buf: &mut B,
+    pub async fn read_blocks_at<'a, B: AsMut<[u8]>>(
+        &'a mut self,
+        buf: &'a mut B,
         offset_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let buf = buf.as_mut();
             let logical_block_size = this.device().logical_block_size() as usize;
 
@@ -487,16 +502,16 @@ impl IoChannel {
 
     /// Reads data from the block device at the specified block offset into the
     /// slice of buffers.
-    pub async fn read_vectored_blocks_at<'b, B>(
-        &mut self,
-        bufs: &'b mut B,
+    pub async fn read_vectored_blocks_at<'a, B>(
+        &'a mut self,
+        bufs: &'a mut B,
         offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno>
     where
-        B: AsMut<[IoSliceMut<'b>]> + ?Sized,
+        B: AsMut<[IoSliceMut<'a>]> + ?Sized,
     {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let bufs = bufs.as_mut();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -522,13 +537,13 @@ impl IoChannel {
     }
 
     /// Copies blocks from the source block offset to the destination block offset.
-    pub async fn copy_blocks(
-        &mut self,
+    pub async fn copy_blocks<'a>(
+        &'a mut self,
         src_offset_blocks: u64,
         dst_offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -553,8 +568,8 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of bytes is no longer
     /// valid.
-    pub async fn unmap(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn unmap<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -578,8 +593,12 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of blocks is no longer
     /// valid.
-    pub async fn unmap_blocks(&mut self, offset_blocks: u64, num_blocks: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn unmap_blocks<'a>(
+        &'a mut self,
+        offset_blocks: u64,
+        num_blocks: u64,
+    ) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -606,8 +625,8 @@ impl IoChannel {
     ///
     /// For devices with volatile cache, data is not guaranteed to be persistent
     /// until the completion of the flush operation.
-    pub async fn flush(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn flush<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
@@ -630,8 +649,8 @@ impl IoChannel {
     }
 
     /// Resets the block device.
-    pub async fn reset(&mut self) -> Result<(), Errno> {
-        self.execute_io(|this, p| {
+    pub async fn reset<'a>(&'a mut self) -> Result<(), Errno> {
+        self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {

--- a/spdk/src/block/io_channel.rs
+++ b/spdk/src/block/io_channel.rs
@@ -126,7 +126,7 @@ impl IoChannel {
     ///
     /// This function returns `Err(EINVAL)` if the I/O channel an I/O buffer is
     /// available on the current thread..
-    async fn wait_io_available(&self) -> Result<(), Errno> {
+    async fn wait_io_available(&mut self) -> Result<(), Errno> {
         Promise::with_context_cyclic(|w| IoWait::new(w, self))
             .request(|p| {
                 let wait: &IoWait = Promissory::user_context(p);
@@ -157,12 +157,12 @@ impl IoChannel {
 
     /// Executes an I/O operation, queuing the I/O for later execution if there
     /// are no `spdk_bdev_io` structures available.
-    async fn execute_io<F>(&self, mut start_fn: F) -> Result<(), Errno>
+    async fn execute_io<F>(&mut self, mut start_fn: F) -> Result<(), Errno>
     where
-        F: FnMut(&mut Rc<Promissory<()>>) -> Poll<Result<(), Errno>>,
+        F: FnMut(&mut Self, &mut Rc<Promissory<()>>) -> Poll<Result<(), Errno>>,
     {
         loop {
-            match Promise::new().request(|p| (start_fn)(p)).await {
+            match Promise::new().request(|p| (start_fn)(self, p)).await {
                 Ok(()) => return Ok(()),
                 Err(e) if e != ENOMEM => return Err(e),
                 Err(_) => self.wait_io_available().await?,
@@ -171,15 +171,15 @@ impl IoChannel {
     }
 
     /// Resets the block device zone.
-    pub async fn reset_zone(&self, zone_id: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn reset_zone(&mut self, zone_id: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_zone_management(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         zone_id,
                         SPDK_BDEV_ZONE_RESET,
                         Some(cb_fn),
@@ -196,16 +196,16 @@ impl IoChannel {
 
     /// Writes the data in the buffer to the block device at the specified
     /// byte offset.
-    pub async fn write_at<B: AsRef<[u8]>>(&self, buf: &B, offset: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn write_at<B: AsRef<[u8]>>(&mut self, buf: &B, offset: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let buf = buf.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_write(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of!(*buf) as *mut c_void,
                         offset,
                         buf.len() as u64,
@@ -224,7 +224,7 @@ impl IoChannel {
     /// Writes the data in the slice of buffers to the block device at the specified
     /// byte offset.
     pub async fn write_vectored_at<'b, B>(
-        &self,
+        &mut self,
         bufs: &'b B,
         offset: u64,
         length: u64,
@@ -232,15 +232,15 @@ impl IoChannel {
     where
         B: AsRef<[IoSlice<'b>]> + ?Sized,
     {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let bufs = bufs.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_writev(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of!(*bufs) as *mut IoVec,
                         bufs.len() as i32,
                         offset,
@@ -262,13 +262,13 @@ impl IoChannel {
     ///
     /// The buffer length must be a multiple of the block size of the device.
     pub async fn write_blocks_at<B: AsRef<[u8]>>(
-        &self,
+        &mut self,
         buf: &B,
         offset_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let buf = buf.as_ref();
-            let logical_block_size = self.device().logical_block_size() as usize;
+            let logical_block_size = this.device().logical_block_size() as usize;
 
             if (buf.len() % logical_block_size) != 0 {
                 return Poll::Ready(Err(EINVAL));
@@ -279,8 +279,8 @@ impl IoChannel {
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_write_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of!(*buf) as *mut c_void,
                         offset_blocks,
                         (buf.len() / logical_block_size) as u64,
@@ -299,7 +299,7 @@ impl IoChannel {
     /// Writes the data in the slice of buffers to the block device at the specified
     /// block offset.
     pub async fn write_vectored_blocks_at<'b, B>(
-        &self,
+        &mut self,
         bufs: &'b B,
         offset_blocks: u64,
         num_blocks: u64,
@@ -307,15 +307,15 @@ impl IoChannel {
     where
         B: AsRef<[IoSlice<'b>]> + ?Sized,
     {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let bufs = bufs.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_writev_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of!(*bufs) as *mut IoVec,
                         bufs.len() as i32,
                         offset_blocks,
@@ -333,15 +333,15 @@ impl IoChannel {
     }
 
     /// Writes zeroes to the block device at the specified byte offset.
-    pub async fn write_zeroes_at(&self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn write_zeroes_at(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_write_zeroes(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         offset,
                         len,
                         Some(cb_fn),
@@ -358,18 +358,18 @@ impl IoChannel {
 
     /// Writes zeroes to the block device at the specified block offset.
     pub async fn write_zeroes_blocks_at(
-        &self,
+        &mut self,
         offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_write_zeroes_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         offset_blocks,
                         num_blocks,
                         Some(cb_fn),
@@ -386,15 +386,15 @@ impl IoChannel {
 
     /// Reads data from the block device at the specified byte offset into the
     /// buffer.
-    pub async fn read_at<B: AsMut<[u8]>>(&self, buf: &mut B, offset: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn read_at<B: AsMut<[u8]>>(&mut self, buf: &mut B, offset: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_read(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of_mut!(*buf.as_mut()) as *mut c_void,
                         offset,
                         buf.as_mut().len() as u64,
@@ -413,7 +413,7 @@ impl IoChannel {
     /// Reads data from the block device at the specified byte offset into the
     /// slice of buffers.
     pub async fn read_vectored_at<'b, B>(
-        &self,
+        &mut self,
         bufs: &'b mut B,
         offset: u64,
         length: u64,
@@ -421,15 +421,15 @@ impl IoChannel {
     where
         B: AsMut<[IoSliceMut<'b>]> + ?Sized,
     {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let bufs = bufs.as_mut();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_readv(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of_mut!(*bufs) as *mut IoVec,
                         bufs.len() as i32,
                         offset,
@@ -451,13 +451,13 @@ impl IoChannel {
     ///
     /// The buffer must be a multiple of the block size of the device.
     pub async fn read_blocks_at<B: AsMut<[u8]>>(
-        &self,
+        &mut self,
         buf: &mut B,
         offset_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let buf = buf.as_mut();
-            let logical_block_size = self.device().logical_block_size() as usize;
+            let logical_block_size = this.device().logical_block_size() as usize;
 
             if (buf.len() % logical_block_size) != 0 {
                 return Poll::Ready(Err(EINVAL));
@@ -468,8 +468,8 @@ impl IoChannel {
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_read_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of_mut!(*buf) as *mut c_void,
                         offset_blocks,
                         (buf.len() / logical_block_size) as u64,
@@ -488,7 +488,7 @@ impl IoChannel {
     /// Reads data from the block device at the specified block offset into the
     /// slice of buffers.
     pub async fn read_vectored_blocks_at<'b, B>(
-        &self,
+        &mut self,
         bufs: &'b mut B,
         offset_blocks: u64,
         num_blocks: u64,
@@ -496,15 +496,15 @@ impl IoChannel {
     where
         B: AsMut<[IoSliceMut<'b>]> + ?Sized,
     {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let bufs = bufs.as_mut();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_readv_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         addr_of_mut!(*bufs) as *mut IoVec,
                         bufs.len() as i32,
                         offset_blocks,
@@ -523,19 +523,19 @@ impl IoChannel {
 
     /// Copies blocks from the source block offset to the destination block offset.
     pub async fn copy_blocks(
-        &self,
+        &mut self,
         src_offset_blocks: u64,
         dst_offset_blocks: u64,
         num_blocks: u64,
     ) -> Result<(), Errno> {
-        self.execute_io(|p| {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_copy_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         src_offset_blocks,
                         dst_offset_blocks,
                         num_blocks,
@@ -553,15 +553,15 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of bytes is no longer
     /// valid.
-    pub async fn unmap(&self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn unmap(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_unmap(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         offset,
                         len,
                         Some(cb_fn),
@@ -578,15 +578,15 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of blocks is no longer
     /// valid.
-    pub async fn unmap_blocks(&self, offset_blocks: u64, num_blocks: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn unmap_blocks(&mut self, offset_blocks: u64, num_blocks: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_unmap_blocks(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         offset_blocks,
                         num_blocks,
                         Some(cb_fn),
@@ -606,15 +606,15 @@ impl IoChannel {
     ///
     /// For devices with volatile cache, data is not guaranteed to be persistent
     /// until the completion of the flush operation.
-    pub async fn flush(&self, offset: u64, len: u64) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn flush(&mut self, offset: u64, len: u64) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_flush(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         offset,
                         len,
                         Some(cb_fn),
@@ -630,15 +630,15 @@ impl IoChannel {
     }
 
     /// Resets the block device.
-    pub async fn reset(&self) -> Result<(), Errno> {
-        self.execute_io(|p| {
+    pub async fn reset(&mut self) -> Result<(), Errno> {
+        self.execute_io(|this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
             to_poll_pending_on_ok! {
                 unsafe {
                     spdk_bdev_reset(
-                        self.descriptor(),
-                        self.as_ptr(),
+                        this.descriptor(),
+                        this.as_ptr(),
                         Some(cb_fn),
                         cb_arg.cast_mut() as *mut _,
                     )

--- a/spdk/src/nvmf/subsystem.rs
+++ b/spdk/src/nvmf/subsystem.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::{c_void, CStr},
+    marker::PhantomData,
     ptr::{null_mut, NonNull},
     task::Poll,
 };
@@ -75,7 +76,7 @@ impl Subsystem {
     }
 
     /// Sets the serial number of the subsystem.
-    pub fn set_serial_number(&self, sn: &CStr) -> Result<(), Errno> {
+    pub fn set_serial_number(&mut self, sn: &CStr) -> Result<(), Errno> {
         unsafe {
             if spdk_nvmf_subsystem_set_sn(self.as_ptr(), sn.as_ptr()) < 0 {
                 return Err(EINVAL);
@@ -91,7 +92,7 @@ impl Subsystem {
     }
 
     /// Sets the model number of the subsystem.
-    pub fn set_model_number(&self, mn: &CStr) -> Result<(), Errno> {
+    pub fn set_model_number(&mut self, mn: &CStr) -> Result<(), Errno> {
         unsafe {
             if spdk_nvmf_subsystem_set_mn(self.as_ptr(), mn.as_ptr()) < 0 {
                 return Err(EINVAL);
@@ -123,7 +124,7 @@ impl Subsystem {
 
     /// Sets whether the subsystem allows any host to connect or only hosts in
     /// the allowed list.
-    pub fn allow_any_host(&self, allow: bool) {
+    pub fn allow_any_host(&mut self, allow: bool) {
         unsafe {
             spdk_nvmf_subsystem_set_allow_any_host(self.as_ptr(), allow);
         }
@@ -136,7 +137,7 @@ impl Subsystem {
     }
 
     /// Adds a host NQN to the allowed list.
-    pub fn allow_host(&self, host_nqn: &CStr) -> Result<(), Errno> {
+    pub fn allow_host(&mut self, host_nqn: &CStr) -> Result<(), Errno> {
         unsafe {
             to_result!(spdk_nvmf_subsystem_add_host(
                 self.as_ptr(),
@@ -155,7 +156,7 @@ impl Subsystem {
     ///
     /// Returns `Ok(true)` if the host was removed from the allowed list, and
     /// `Ok(false)` if the host was not in the allowed list.
-    pub fn deny_host(&self, host_nqn: &CStr) -> Result<bool, Errno> {
+    pub fn deny_host(&mut self, host_nqn: &CStr) -> Result<bool, Errno> {
         let res = unsafe {
             to_result!(spdk_nvmf_subsystem_remove_host(
                 self.as_ptr(),
@@ -194,8 +195,8 @@ impl Subsystem {
     /// Starts the subsystem.
     ///
     /// This method transitions of the subsystem from the Inactive to Active state.
-    pub async fn start(&self) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn start<'a>(&'a mut self) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
                     (Self::complete_state_change, Promissory::into_raw(p.clone()));
@@ -219,8 +220,8 @@ impl Subsystem {
     /// Stops the subsystem.
     ///
     /// This method transitions of the subsystem from the Active to Inactive state.
-    pub async fn stop(&self) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn stop<'a>(&'a mut self) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
                     (Self::complete_state_change, Promissory::into_raw(p.clone()));
@@ -250,8 +251,8 @@ impl Subsystem {
     /// namespace are quiesced and incoming commands are queued until the
     /// subsystem is resumed. A namespace identifier of 0 indicates that no
     /// namespace is paused while `SPDK_NVME_GLOBAL_NS_TAG` pauses all namespaces.
-    pub async fn pause(&self, ns: u32) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn pause<'a>(&'a mut self, ns: u32) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
                     (Self::complete_state_change, Promissory::into_raw(p.clone()));
@@ -276,8 +277,8 @@ impl Subsystem {
     /// Resumes the subsystem.
     ///
     /// This method transitions of the subsystem from the Inactive to Paused state.
-    pub async fn resume(&self) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn resume<'a>(&'a mut self) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
                     (Self::complete_state_change, Promissory::into_raw(p.clone()));
@@ -302,7 +303,7 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to add a
     /// namespace.
-    pub fn add_namespace(&self, device_name: &CStr) -> Result<Namespace, Errno> {
+    pub fn add_namespace(&mut self, device_name: &CStr) -> Result<Namespace, Errno> {
         unsafe {
             let nsid = spdk_nvmf_subsystem_add_ns_ext(
                 self.as_ptr(),
@@ -326,7 +327,7 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to remove a
     /// namespace.
-    pub fn remove_namespace(&self, nsid: u32) -> Result<(), Errno> {
+    pub fn remove_namespace(&mut self, nsid: u32) -> Result<(), Errno> {
         unsafe { to_result!(spdk_nvmf_subsystem_remove_ns(self.as_ptr(), nsid)) }
     }
 
@@ -339,8 +340,8 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to add a
     /// listener.
-    pub async fn add_listener(&self, transport_id: &TransportId) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn add_listener<'a>(&'a mut self, transport_id: &TransportId) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
@@ -364,7 +365,7 @@ impl Subsystem {
     ///
     /// Returns `Ok(true)` if the listener was removed, and `Ok(false)` if no
     /// listener was listening on the given transport.
-    pub fn remove_listener(&self, transport_id: &TransportId) -> Result<bool, Errno> {
+    pub fn remove_listener(&mut self, transport_id: &TransportId) -> Result<bool, Errno> {
         let res = unsafe {
             to_result!(spdk_nvmf_subsystem_remove_listener(
                 self.as_ptr(),

--- a/spdk/src/nvmf/target.rs
+++ b/spdk/src/nvmf/target.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::CStr,
     io::Write,
+    marker::PhantomData,
     mem::{self, size_of_val, MaybeUninit},
     ptr::{copy_nonoverlapping, NonNull},
     task::Poll,
@@ -220,8 +221,8 @@ impl Target {
     }
 
     /// Adds a transport to the target.
-    pub async fn add_transport(&mut self, transport: Transport) -> Result<(), Errno> {
-        let res = Promise::new()
+    pub async fn add_transport<'a>(&'a mut self, transport: Transport) -> Result<(), Errno> {
+        let res = Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
 
@@ -264,7 +265,8 @@ impl Target {
 
     /// Enables the NVMe-oF Discovery Controller subsystem on this target.
     pub fn enable_discovery(&mut self) -> Result<Subsystem, Errno> {
-        let discovery = self.add_subsystem(SPDK_NVMF_DISCOVERY_NQN, SubsystemType::Discovery, 0)?;
+        let mut discovery =
+            self.add_subsystem(SPDK_NVMF_DISCOVERY_NQN, SubsystemType::Discovery, 0)?;
 
         discovery.allow_any_host(true);
         Ok(discovery)
@@ -299,8 +301,8 @@ impl Target {
     }
 
     /// Removes a subsystem from the target.
-    pub async fn remove_subsystem(&mut self, subsys: Subsystem) -> Result<(), Errno> {
-        Promise::new()
+    pub async fn remove_subsystem<'a>(&'a mut self, subsys: Subsystem) -> Result<(), Errno> {
+        Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
 
@@ -327,8 +329,8 @@ impl Target {
     }
 
     /// Starts the subsystems on this target.
-    pub async fn start_subsystems(&self) -> Result<(), Errno> {
-        for subsys in self.subsystems() {
+    pub async fn start_subsystems(&mut self) -> Result<(), Errno> {
+        for mut subsys in self.subsystems() {
             subsys.start().await?;
         }
 
@@ -336,8 +338,8 @@ impl Target {
     }
 
     /// Stops the subsystems on this target.
-    pub async fn stop_subsystems(&self) -> Result<(), Errno> {
-        for subsys in self.subsystems() {
+    pub async fn stop_subsystems(&mut self) -> Result<(), Errno> {
+        for mut subsys in self.subsystems() {
             subsys.stop().await?;
         }
 
@@ -345,8 +347,8 @@ impl Target {
     }
 
     /// Pauses the subsystems on this target.
-    pub async fn pause_subsystems(&self) -> Result<(), Errno> {
-        for subsys in self.subsystems() {
+    pub async fn pause_subsystems(&mut self) -> Result<(), Errno> {
+        for mut subsys in self.subsystems() {
             subsys.pause(SPDK_NVME_GLOBAL_NS_TAG).await?;
         }
 
@@ -354,8 +356,8 @@ impl Target {
     }
 
     /// Resumes the subsystems on this target.
-    pub async fn resume_subsystems(&self) -> Result<(), Errno> {
-        for subsys in self.subsystems() {
+    pub async fn resume_subsystems(&mut self) -> Result<(), Errno> {
+        for mut subsys in self.subsystems() {
             subsys.resume().await?;
         }
 
@@ -363,7 +365,7 @@ impl Target {
     }
 
     /// Begins accepting new connections on the specified transport.
-    pub fn listen(&self, transport_id: &TransportId) -> Result<(), Errno> {
+    pub fn listen(&mut self, transport_id: &TransportId) -> Result<(), Errno> {
         unsafe {
             let mut opts = MaybeUninit::uninit();
 

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -34,7 +34,7 @@ use crate::{
 #[derive(Debug, Default)]
 enum PromiseState<T>
 where
-    T: Debug + 'static,
+    T: Debug,
 {
     /// The initial state of a promise.
     #[default]
@@ -72,7 +72,7 @@ unsafe impl<T> Send for PromiseState<T> where T: Debug + Send + 'static {}
 
 impl<T> PromiseState<T>
 where
-    T: Debug + 'static,
+    T: Debug,
 {
     /// Polls the state of the operation, advancing to the next state if possible.
     fn poll(&mut self, cx: &Context<'_>) -> Self {
@@ -115,7 +115,7 @@ where
 /// </div>
 pub struct Promissory<R, C = ()>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     state: RefCell<PromiseState<R>>,
     thread: Thread,
@@ -124,7 +124,7 @@ where
 
 impl<R, C> Promissory<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
     C: Unpin,
 {
     /// Returns a new `Rc<Promise>` instance with the provided context.
@@ -154,7 +154,7 @@ where
 
 impl<R, C> Promissory<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     /// Constructs a new `Rc<Promissory>` instance initializing the context, `C` in place. This
     /// function also provides a `Weak<Promissory>` to the allocation allowing you to initialize the
@@ -344,7 +344,7 @@ impl<C> Promissory<(), C> {
 
 impl<R, C> Default for Promissory<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
     C: Default,
 {
     fn default() -> Self {
@@ -359,11 +359,11 @@ where
 /// A future implementation for awaiting the result of a [`Promise`].
 struct FuturePromise<R, C>(Rc<Promissory<R, C>>)
 where
-    R: Debug + 'static;
+    R: Debug;
 
 impl<R, C> Future for FuturePromise<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     type Output = Result<R, Errno>;
 
@@ -387,13 +387,13 @@ where
 /// </div>
 pub struct Promise<R, C = ()>(Rc<Promissory<R, C>>)
 where
-    R: Debug + 'static;
+    R: Debug;
 
 unsafe impl<R, C> Send for Promise<R, C> where R: Debug + Send + 'static {}
 
 impl<R> Promise<R>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     /// Returns a new `Promise` instance.
     ///
@@ -408,7 +408,7 @@ where
 
 impl<R> Default for Promise<R>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     fn default() -> Self {
         Self::new()
@@ -417,7 +417,7 @@ where
 
 impl<R, C> Promise<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
     C: Unpin,
 {
     /// Returns a new `Promise` instance with the user context of the related `Promissory`
@@ -451,7 +451,7 @@ where
 
 impl<R, C> Promise<R, C>
 where
-    R: Debug + 'static,
+    R: Debug,
 {
     /// Constructs a new `Promise` instance initializing the context, `C`, in place in the related
     /// `Promissory` allocation. This function also provides a `Weak<Promissory>` to the allocation

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -116,7 +116,6 @@ where
 pub struct Promissory<R, C = ()>
 where
     R: Debug + 'static,
-    C: 'static,
 {
     state: RefCell<PromiseState<R>>,
     thread: Thread,
@@ -126,7 +125,7 @@ where
 impl<R, C> Promissory<R, C>
 where
     R: Debug + 'static,
-    C: Unpin + 'static,
+    C: Unpin,
 {
     /// Returns a new `Rc<Promise>` instance with the provided context.
     pub fn with_context(ctx: C) -> Rc<Self> {
@@ -156,7 +155,6 @@ where
 impl<R, C> Promissory<R, C>
 where
     R: Debug + 'static,
-    C: 'static,
 {
     /// Constructs a new `Rc<Promissory>` instance initializing the context, `C` in place. This
     /// function also provides a `Weak<Promissory>` to the allocation allowing you to initialize the
@@ -253,7 +251,6 @@ where
     unsafe extern "C" fn complete_with_object<T>(cx: *mut c_void, obj: *mut T)
     where
         R: Debug + TryFrom<*mut T, Error = Errno> + 'static,
-        C: 'static,
     {
         let rc_self = Self::from_raw(cx.cast());
 
@@ -348,7 +345,7 @@ impl<C> Promissory<(), C> {
 impl<R, C> Default for Promissory<R, C>
 where
     R: Debug + 'static,
-    C: Default + 'static,
+    C: Default,
 {
     fn default() -> Self {
         Self {
@@ -362,13 +359,11 @@ where
 /// A future implementation for awaiting the result of a [`Promise`].
 struct FuturePromise<R, C>(Rc<Promissory<R, C>>)
 where
-    R: Debug + 'static,
-    C: 'static;
+    R: Debug + 'static;
 
 impl<R, C> Future for FuturePromise<R, C>
 where
     R: Debug + 'static,
-    C: 'static,
 {
     type Output = Result<R, Errno>;
 
@@ -392,15 +387,9 @@ where
 /// </div>
 pub struct Promise<R, C = ()>(Rc<Promissory<R, C>>)
 where
-    R: Debug + 'static,
-    C: 'static;
+    R: Debug + 'static;
 
-unsafe impl<R, C> Send for Promise<R, C>
-where
-    R: Debug + Send + 'static,
-    C: 'static,
-{
-}
+unsafe impl<R, C> Send for Promise<R, C> where R: Debug + Send + 'static {}
 
 impl<R> Promise<R>
 where
@@ -429,7 +418,7 @@ where
 impl<R, C> Promise<R, C>
 where
     R: Debug + 'static,
-    C: Unpin + 'static,
+    C: Unpin,
 {
     /// Returns a new `Promise` instance with the user context of the related `Promissory`
     /// initialized to the specified value.
@@ -463,7 +452,6 @@ where
 impl<R, C> Promise<R, C>
 where
     R: Debug + 'static,
-    C: 'static,
 {
     /// Constructs a new `Promise` instance initializing the context, `C`, in place in the related
     /// `Promissory` allocation. This function also provides a `Weak<Promissory>` to the allocation

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -254,7 +254,7 @@ impl Thread {
     /// [`Thread::send_msg()`]: method@Thread::send_msg
     unsafe extern "C" fn handle_msg<F>(ctx: *mut c_void)
     where
-        F: FnOnce() + 'static,
+        F: FnOnce(),
     {
         let msg_fn = Box::from_raw(ctx as *mut F);
 
@@ -288,7 +288,7 @@ impl Thread {
     /// [`ENOMEM`]: crate::errors::ENOMEM
     pub fn send_msg<F>(&self, f: F) -> Result<(), Errno>
     where
-        F: FnOnce() + 'static,
+        F: FnOnce(),
     {
         let ctx = Box::into_raw(Box::new(f)).cast();
 


### PR DESCRIPTION
Enforces single ownership (i.e. `&mut self`) for asynchronous operations and adds lifetime markers for `self` and parameters references that need to live for the duration of the op.