### PR TITLE
feat(net): adds socket groups

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -204,6 +204,57 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "Debug example 'net_group (Server)'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=net_group",
+                    "--package=spdk",
+                    "--features=net"
+                ],
+                "filter": {
+                    "name": "net_group",
+                    "kind": "example"
+                }
+            },
+            "args": [
+                "--iova-mode=va",
+                "--huge-dir=/mnt/hugepages",
+                "--logflag=all",
+                "--no-rpc-server",
+                "--lcores=0",
+                "--server-mode"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'net_group (Client)'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=net_group",
+                    "--package=spdk",
+                    "--features=net"
+                ],
+                "filter": {
+                    "name": "net_group",
+                    "kind": "example"
+                }
+            },
+            "args": [
+                "--iova-mode=va",
+                "--huge-dir=/mnt/hugepages",
+                "--logflag=all",
+                "--lcores=1",
+                "--no-rpc-server"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "Debug example 'net_hello_world (Server)'",
             "cargo": {
                 "args": [

--- a/spdk/Cargo.toml
+++ b/spdk/Cargo.toml
@@ -53,6 +53,10 @@ name = "module_passthru"
 required-features = ["bdev-malloc", "bdev-module"]
 
 [[example]]
+name = "net_group"
+required-features = ["net"]
+
+[[example]]
 name = "net_hello_world"
 required-features = ["net"]
 

--- a/spdk/examples/net_group.rs
+++ b/spdk/examples/net_group.rs
@@ -6,7 +6,7 @@ use spdk::{
     self,
     cli::Parser,
     errors::Errno,
-    net::{Accepted, TcpListener, TcpSocketExt, TcpSocketRemote, TcpStream},
+    net::{Accepted, SocketGroup, TcpSocketExt, TcpSocketRemote, TcpStream},
     task::JoinHandle,
     thread::{self, Thread},
 };
@@ -32,7 +32,8 @@ async fn handle_client(client: Accepted) -> Result<(), Errno> {
 
     Thread::new(&name, &Thread::current().cpuset())?
         .spawn(move || async {
-            let mut client = client.into_stream();
+            let group = SocketGroup::new();
+            let mut client = group.add(client)?;
             let mut msg = String::new();
 
             client.read_to_string(&mut msg).await?;
@@ -50,7 +51,8 @@ async fn handle_client(client: Accepted) -> Result<(), Errno> {
 
 fn run_server(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
     thread::spawn_local(async move {
-        let mut listener = TcpListener::bind(args.host.as_str()).await?;
+        let group = SocketGroup::new();
+        let mut listener = group.bind(args.host.as_str()).await?;
 
         println!(
             "SERVER: Listening on {}",

--- a/spdk/src/errors.rs
+++ b/spdk/src/errors.rs
@@ -51,6 +51,7 @@ impl Debug for Errno {
 impl Error for Errno {}
 
 define_errno! {
+    SUCCESS = 0,
     EPERM = 1,
     ENOENT = 2,
     ESRCH = 3,

--- a/spdk/src/net/addr.rs
+++ b/spdk/src/net/addr.rs
@@ -1,3 +1,4 @@
+//! Facilities for resolving IPv4 and IPv6 addresses asynchronously.
 use std::{
     ffi::{CStr, CString},
     fmt::Display,
@@ -104,7 +105,7 @@ impl SocketAddr {
     /// The caller must ensure that `addr` points to a valid `addrinfo` structure.
     ///
     /// [`addrinfo`]: https://www.man7.org/linux/man-pages/man3/getaddrinfo.3.html
-    unsafe fn from_raw(addr: *mut addrinfo) -> Self {
+    unsafe fn from_addrinfo(addr: *mut addrinfo) -> Self {
         let addr = unsafe { &*addr };
         let mut host = [0u8; 1025];
         let mut serv = [0u8; 32];
@@ -236,7 +237,7 @@ impl Iterator for SocketAddrIter {
             return None;
         }
 
-        let addr = unsafe { SocketAddr::from_raw(self.current) };
+        let addr = unsafe { SocketAddr::from_addrinfo(self.current) };
         self.current = unsafe { (*self.current).ai_next };
 
         Some(addr)

--- a/spdk/src/net/group.rs
+++ b/spdk/src/net/group.rs
@@ -1,0 +1,479 @@
+//! Contains the SPDK socket group based TCP listener and stream implementations.
+//!
+//! An SPDK socket group provides a more efficient polling mechanism for multiple sockets than
+//! creating separate pollers for each.
+use std::{
+    mem::{MaybeUninit, transmute},
+    os::raw::c_void,
+    pin::Pin,
+    ptr::null_mut,
+    rc::Rc,
+    task::{Context, Poll},
+};
+
+use futures::task::noop_waker_ref;
+use spdk_sys::{
+    spdk_sock, spdk_sock_group, spdk_sock_group_add_sock, spdk_sock_group_close,
+    spdk_sock_group_create, spdk_sock_group_poll, spdk_sock_group_remove_sock, spdk_sock_opts,
+};
+
+use crate::{
+    errors::{EINVAL, Errno},
+    net::ToSocketAddrs,
+    task::{Polled, Poller},
+    thread::Thread,
+    to_result,
+};
+
+use super::{
+    Accepted, AsRawSock, Connector, RawTcpListener, RawTcpListenerVtable, RawTcpStream,
+    RawTcpStreamVtable, SocketAddr, TcpListener, TcpListenerSocket, TcpStream, TcpStreamSocket,
+};
+
+/// Handles events from a socket group.
+pub(crate) trait SocketGroupEvent: AsRawSock {
+    /// Handles an event notification from a socket group.
+    fn handle_event(self: Pin<&mut Self>);
+}
+
+/// A stub trait implementation to enable initialization of a socket group event handler in-place.
+impl<T> SocketGroupEvent for MaybeUninit<T>
+where
+    T: SocketGroupEvent,
+{
+    fn handle_event(self: Pin<&mut Self>) {
+        unreachable!("handle_event called on uninitialized data");
+    }
+}
+
+/// A member of a socket group.
+struct Grouped<T>
+where
+    T: SocketGroupEvent,
+{
+    group: Rc<Poller<SocketGroupInner>>,
+    sock: T,
+}
+
+impl<T> Grouped<T>
+where
+    T: SocketGroupEvent + Unpin,
+{
+    /// Creates a new instance of a socket group member.
+    fn new(group: Rc<Poller<SocketGroupInner>>, sock: T) -> Box<Self> {
+        Box::new(Self { group, sock })
+    }
+}
+
+impl<T> Grouped<T>
+where
+    T: SocketGroupEvent,
+{
+    /// Initializes a new socket group member in-place.
+    fn new_in_place<I>(group: Rc<Poller<SocketGroupInner>>, init_fn: I) -> Box<Self>
+    where
+        I: FnOnce(Pin<&mut MaybeUninit<T>>),
+    {
+        let mut this = Box::new_uninit();
+        let this_ref = this.write(Grouped {
+            group,
+            sock: MaybeUninit::uninit(),
+        });
+
+        init_fn(unsafe { Pin::new_unchecked(&mut this_ref.sock) });
+
+        // SAFETY: The group member has just been initialized.
+        unsafe { transmute(this) }
+    }
+
+    /// Handles an event notification from the socket group.
+    unsafe extern "C" fn handle_event(
+        arg: *mut c_void,
+        _group: *mut spdk_sock_group,
+        _sock: *mut spdk_sock,
+    ) {
+        let grouped = unsafe { &mut *(arg as *mut Grouped<T>) };
+
+        unsafe { Pin::new_unchecked(&mut grouped.sock) }.handle_event();
+    }
+}
+
+impl<T> Drop for Grouped<T>
+where
+    T: SocketGroupEvent,
+{
+    fn drop(&mut self) {
+        self.group
+            .polled()
+            .remove(&self.sock)
+            .expect("socket removed");
+    }
+}
+
+/// Returns the [`RawTcpListener`]'s raw `spdk_sock` pointer.
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpListenerSocket`]`>` instance.
+fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpListenerSocket>) };
+
+    this.sock.as_raw_sock()
+}
+
+/// Polls the [`RawTcpListener`] for an incoming connection.
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpListenerSocket`]`>` instance.
+///
+/// # Returns
+///
+/// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
+/// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a
+/// [`TcpStream`].
+fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpListenerSocket>) };
+
+    Pin::new(&mut this.sock).poll_accept(cx)
+}
+
+/// Drops the [`RawTcpListener`].
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpListenerSocket`]`>` instance.
+fn listener_drop(data: *const ()) {
+    drop(unsafe { Box::from_raw(data as *mut Grouped<TcpListenerSocket>) });
+}
+
+/// Returns the [`RawTcpListenerVtable`] used by a [`RawTcpListener`].
+///
+/// This virtual function table enables dynamic dispatch to a [`Grouped`]`<`[`TcpListenerSocket`]`>`
+/// instance.
+fn listener_vtable() -> &'static RawTcpListenerVtable {
+    &RawTcpListenerVtable {
+        as_raw_sock: listener_as_raw_sock,
+        poll_accept: listener_poll_accept,
+        drop: listener_drop,
+    }
+}
+
+/// Returns the [`RawTcpStream`]'s raw `spdk_sock` pointer.
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    this.sock.as_raw_sock()
+}
+
+/// Polls the connection state of the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
+/// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
+fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    Pin::new(&mut this.sock).poll_connected(cx)
+}
+
+/// Attempts to read from the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns number of bytes read in `Poll::Ready(Ok(num_bytes_read))` if data was
+/// available and `Poll::Pending` if no data was available.
+///
+/// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
+fn stream_poll_read(
+    data: *const (),
+    cx: &mut Context<'_>,
+    buf: &mut [u8],
+) -> Poll<Result<usize, Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    Pin::new(&mut this.sock).poll_read(cx, buf)
+}
+
+/// Attempts to write to the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns number of bytes written in `Poll::Ready(Ok(num_bytes_written))` if data was
+/// written and `Poll::Pending` data cannot currently be written.
+///
+/// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
+fn stream_poll_write(
+    data: *const (),
+    cx: &mut Context<'_>,
+    buf: &[u8],
+) -> Poll<Result<usize, Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    // A socket group does not provide notification of write buffer availability, so we pass a no-op
+    // waker to the socket's `poll_write` method and queue a thread message to the current thread to
+    // poll for available write buffer space later.
+    match Pin::new(&mut this.sock).poll_write(&mut Context::from_waker(noop_waker_ref()), buf) {
+        Poll::Ready(res) => Poll::Ready(res),
+        Poll::Pending => {
+            let waker = cx.waker().clone();
+
+            Thread::current().send_msg(move || {
+                waker.wake();
+            })?;
+            Poll::Pending
+        }
+    }
+}
+
+/// Attempts to flush buffered data from the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this method
+/// always returns `Poll::Ready(Ok())`.
+fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    Pin::new(&mut this.sock).poll_flush(cx)
+}
+
+/// Attempts to close the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
+/// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
+fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
+
+    Pin::new(&mut this.sock).poll_close(cx)
+}
+
+/// Drops the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>` instance.
+fn stream_drop(data: *const ()) {
+    drop(unsafe { Box::from_raw(data as *mut Grouped<TcpStreamSocket>) });
+}
+
+/// Returns the [`RawTcpStreamVtable`] used by a [`RawTcpStream`].
+///
+/// This virtual function table enables dynamic dispatch to a [`Grouped`]`<`[`TcpStreamSocket`]`>`
+/// instance.
+fn stream_vtable() -> &'static RawTcpStreamVtable {
+    &RawTcpStreamVtable {
+        as_raw_sock: stream_as_raw_sock,
+        poll_connected: stream_poll_connected,
+        poll_read: stream_poll_read,
+        poll_write: stream_poll_write,
+        poll_flush: stream_poll_flush,
+        poll_close: stream_poll_close,
+        drop: stream_drop,
+    }
+}
+
+/// The shared state of a [`SocketGroup`] instance.
+#[derive(Debug)]
+struct SocketGroupInner {
+    group: *mut spdk_sock_group,
+}
+
+impl SocketGroupInner {
+    /// Creates a new [`SocketGroupInner`] instance, initializing it in-place.
+    fn new_in_place(mut this: Pin<&mut MaybeUninit<Self>>) {
+        let this = this.write(Self { group: null_mut() });
+
+        this.group = unsafe { spdk_sock_group_create(this as *mut _ as *mut _) };
+    }
+
+    /// Creates a new [`TcpListener`] bound to the specified socket address and attached to this
+    /// [`SocketGroup`].
+    ///
+    /// If the port number of the socket address is omitted or `0`, the operating system will assign
+    /// a port to this listener. The allocated port can be discovered by calling the
+    /// [`TcpSocketExt::local_addr()`] method.
+    ///
+    /// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
+    fn bind(this: &Rc<Poller<Self>>, addr: SocketAddr) -> Result<TcpListener, Errno> {
+        let mut listener = Grouped::new(this.clone(), TcpListenerSocket::bind(addr)?);
+
+        to_result!(unsafe {
+            spdk_sock_group_add_sock(
+                this.polled().group,
+                listener.sock.as_raw_sock(),
+                Some(Grouped::<TcpListenerSocket>::handle_event),
+                listener.as_mut() as *mut _ as *mut _,
+            )
+        })?;
+
+        // SAFETY: The `vtable` matches the `data` pointer type.
+        Ok(TcpListener::new(unsafe {
+            RawTcpListener::new(Box::into_raw(listener).cast(), listener_vtable())
+        }))
+    }
+
+    /// Adds a new incoming connection producing a [`TcpStream`] attached to this [`SocketGroup`].
+    fn add(this: &Rc<Poller<Self>>, accepted: Accepted) -> Result<TcpStream, Errno> {
+        let mut stream = Grouped::new(this.clone(), accepted.into_socket());
+
+        to_result!(unsafe {
+            spdk_sock_group_add_sock(
+                this.polled().group,
+                stream.sock.as_raw_sock(),
+                Some(Grouped::<TcpStreamSocket>::handle_event),
+                stream.as_mut() as *mut _ as *mut _,
+            )
+        })?;
+
+        // SAFETY: The `vtable` matches the `data` pointer type.
+        Ok(TcpStream::new(unsafe {
+            RawTcpStream::new(Box::into_raw(stream).cast(), stream_vtable())
+        }))
+    }
+
+    /// Creates a [`TcpStream`] connected to the specified socket address and attached to this
+    /// [`SocketGroup`].
+    async fn connect(
+        this: &Rc<Poller<Self>>,
+        addr: SocketAddr,
+        opts: &spdk_sock_opts,
+    ) -> Result<TcpStream, Errno> {
+        let mut stream = Grouped::new_in_place(this.clone(), |stream| {
+            TcpStreamSocket::connect_in_place(stream, addr, opts)
+        });
+
+        to_result!(unsafe {
+            spdk_sock_group_add_sock(
+                this.polled().group,
+                stream.sock.as_raw_sock(),
+                Some(Grouped::<TcpStreamSocket>::handle_event),
+                stream.as_mut() as *mut _ as *mut _,
+            )
+        })?;
+
+        // SAFETY: The `vtable` matches the `data` pointer type.
+        Connector::new(unsafe { RawTcpStream::new(Box::into_raw(stream).cast(), stream_vtable()) })
+            .await
+    }
+
+    /// Removes a TCP socket from this group.
+    ///
+    /// This method is called from the [`Grouped<T: AsRawSock>::drop()`] method when a
+    /// [`TcpListener`] or [`TcpStream`] (via [`RawTcpListener`] or [`RawTcpStream`], respectively)
+    /// group member is dropped. It is not necessary to manually call this method.
+    fn remove<T>(&self, sock: &T) -> Result<(), Errno>
+    where
+        T: AsRawSock,
+    {
+        to_result!(unsafe { spdk_sock_group_remove_sock(self.group, sock.as_raw_sock()) })
+    }
+}
+
+impl Drop for SocketGroupInner {
+    fn drop(&mut self) {
+        to_result!(unsafe { spdk_sock_group_close(&mut self.group) }).expect("socket group closed");
+    }
+}
+
+impl Polled for SocketGroupInner {
+    fn poll(self: Pin<&mut Self>) -> bool {
+        unsafe { spdk_sock_group_poll(self.group) != 0 }
+    }
+}
+
+/// A group of TCP sockets on a single [`Thread`].
+///
+/// `SocketGroup` provides a more efficient polling mechanism for multiple TCP sockets than creating
+/// separate pollers for each.
+pub struct SocketGroup(Rc<Poller<SocketGroupInner>>);
+
+impl SocketGroup {
+    /// Creates a new [`SocketGroup`].
+    pub fn new() -> Self {
+        Self(Rc::new(Poller::new_in_place(
+            SocketGroupInner::new_in_place,
+        )))
+    }
+
+    /// Creates a new [`TcpListener`] bound to the specified socket address and attached to this
+    /// group.
+    ///
+    /// If the port number of the socket address is omitted or `0`, the operating system will assign
+    /// a port to this listener. The allocated port can be discovered by calling the
+    /// [`TcpSocketExt::local_addr()`] method.
+    ///
+    /// If `addr` yields multiple socket address, `bind` will attempt listen on each until one
+    /// succeeds and returns a listener. If no address can be successfully bound, `Err(EINVAL)` is
+    /// returned.
+    ///
+    /// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
+    pub async fn bind<A: ToSocketAddrs>(&self, addrs: A) -> Result<TcpListener, Errno> {
+        for addr in addrs.to_socket_addr().await? {
+            match SocketGroupInner::bind(&self.0, addr) {
+                Ok(listener) => return Ok(listener),
+                Err(_) => continue,
+            }
+        }
+
+        Err(EINVAL)
+    }
+
+    /// Creates a TCP connection to the specified socket address, returning a [`TcpStream`] attached
+    /// to this group on success.
+    ///
+    /// If `addr` yields multiple socket addresses, `connect` will attempt to connect to each until
+    /// one succeeds and returns a stream. If no address can be successfully connected, the error
+    /// from the last connection attempt is returned.
+    pub async fn connect(
+        &self,
+        addr: SocketAddr,
+        opts: &spdk_sock_opts,
+    ) -> Result<TcpStream, Errno> {
+        SocketGroupInner::connect(&self.0, addr, opts).await
+    }
+
+    /// Adds a new incoming connection producing a [`TcpStream`] attached to this group.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use spdk::net::{SocketGroup, TcpListener, TcpStream};
+    ///
+    /// let group = SocketGroup::new();
+    /// let listener = group.bind("127.0.0.1:8080").await?;
+    /// let remote = group.add(listener.accept().await?)?;
+    /// ```
+    pub fn add(&self, accepted: Accepted) -> Result<TcpStream, Errno> {
+        SocketGroupInner::add(&self.0, accepted)
+    }
+}
+
+impl Clone for SocketGroup {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl Default for SocketGroup {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/spdk/src/net/listener.rs
+++ b/spdk/src/net/listener.rs
@@ -66,10 +66,8 @@ pub struct Incoming<'a> {
 
 impl<'a> Incoming<'a> {
     /// Creates new `Incoming` instance for the specified [`TcpListener`].
-    fn new(listener: &'a mut TcpListener) -> Self {
-        Self {
-            listener: listener.inner_mut(),
-        }
+    fn new(listener: &'a mut TcpListenerInner) -> Self {
+        Self { listener }
     }
 }
 
@@ -268,7 +266,7 @@ impl TcpListener {
     /// [`accept`]: TcpListener::accept
     /// [`Thread`]: crate::thread::Thread
     pub fn incoming(&mut self) -> Incoming<'_> {
-        Incoming::new(self)
+        Incoming::new(self.inner_mut())
     }
 }
 

--- a/spdk/src/net/listener.rs
+++ b/spdk/src/net/listener.rs
@@ -1,5 +1,4 @@
 use std::{
-    mem,
     pin::Pin,
     ptr,
     task::{Context, Poll, Waker},
@@ -10,44 +9,13 @@ use spdk_sys::{spdk_sock, spdk_sock_accept, spdk_sock_close, spdk_sock_listen};
 
 use crate::{
     errors::{self, EAGAIN, EBADF, EINVAL, Errno, errno},
-    task::{Polled, Poller},
+    task::Polled,
     to_result,
 };
 
-use super::{AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs};
-
-/// The state of a [`TcpListener`].
-#[derive(Debug)]
-enum ListenerState {
-    /// The listener is idle, i.e. it has not been bound with a [`Waker`] to receive connection
-    /// result notifications.
-    Idle,
-
-    /// The listener has been bound with a [`Waker`] to receive connection result notifications.
-    Waiting(Waker),
-
-    /// A result is available.
-    Available(Result<Accepted, Errno>),
-}
-
-impl ListenerState {
-    /// Polls the state of the listener, advancing to the next state if possible.
-    fn poll(&mut self, cx: &Context<'_>) -> Self {
-        match self {
-            Self::Idle => mem::replace(self, Self::Waiting(cx.waker().clone())),
-            Self::Waiting(waker) => Self::Waiting(waker.clone()),
-            Self::Available(_) => mem::replace(self, Self::Idle),
-        }
-    }
-
-    /// Sets the state of the listener with an available result.
-    fn set_available(&mut self, res: Result<Accepted, Errno>) -> Self {
-        match self {
-            Self::Idle | Self::Waiting(_) => mem::replace(self, Self::Available(res)),
-            _ => unreachable!("set_available called in unexpected state: {:?}", self),
-        }
-    }
-}
+use super::{
+    AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs, bind_polled_listener,
+};
 
 /// An iterator created by calling the [`TcpListener::incoming()`] method that infinitely accepts
 /// connections asynchronously on a [`TcpListener`].
@@ -61,12 +29,12 @@ impl ListenerState {
 /// [`accept`]: TcpListener::accept
 /// [`Thread`]: crate::thread::Thread
 pub struct Incoming<'a> {
-    listener: &'a mut TcpListenerInner,
+    listener: &'a mut RawTcpListener,
 }
 
 impl<'a> Incoming<'a> {
     /// Creates new `Incoming` instance for the specified [`TcpListener`].
-    fn new(listener: &'a mut TcpListenerInner) -> Self {
+    fn new(listener: &'a mut RawTcpListener) -> Self {
         Self { listener }
     }
 }
@@ -75,9 +43,10 @@ impl<'a> Stream for Incoming<'a> {
     type Item = Result<Accepted, Errno>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.get_mut().listener.poll_state(cx) {
-            ListenerState::Idle | ListenerState::Waiting(_) => Poll::Pending,
-            ListenerState::Available(res) => Poll::Ready(Some(res)),
+        unsafe {
+            Pin::map_unchecked_mut(self, |s| s.listener)
+                .poll_accept(cx)
+                .map(Option::Some)
         }
     }
 }
@@ -115,44 +84,62 @@ impl TcpSocketExt for Accepted {}
 
 impl TcpSocketRemote for Accepted {}
 
-/// The internal state of a [`TcpListener`].
 #[derive(Debug)]
-struct TcpListenerInner {
+pub(crate) struct TcpListenerSocket {
     sock: *mut spdk_sock,
-    state: ListenerState,
+    waker: Option<Waker>,
 }
 
-impl TcpListenerInner {
-    /// Attempts to accept a new incoming connection.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Poll::Ready(Ok(Accepted(_)))` if there is a new incoming connection,
-    /// `Poll::Pending` if there is none, and `Poll::Ready(Err(Errno))` if the listener failed to
-    /// bind.
-    fn poll_accept(&self) -> Poll<Result<Accepted, Errno>> {
-        let sock = unsafe { spdk_sock_accept(self.sock) };
+impl TcpListenerSocket {
+    pub(crate) fn bind(addr: SocketAddr) -> Result<Self, Errno> {
+        let sock = unsafe { spdk_sock_listen(addr.ip().as_ptr(), addr.port() as i32, ptr::null()) };
 
         if !sock.is_null() {
-            return Poll::Ready(Ok(Accepted(sock)));
+            return Ok(Self { sock, waker: None });
+        }
+
+        Err(EINVAL)
+    }
+
+    pub(crate) fn poll_accept(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Accepted, Errno>> {
+        let accepted = unsafe { spdk_sock_accept(self.sock) };
+
+        if !accepted.is_null() {
+            return Poll::Ready(Ok(Accepted(accepted)));
         }
 
         let err = errno();
 
         if err == EAGAIN {
+            self.waker = Some(cx.waker().clone());
             return Poll::Pending;
         }
 
         Poll::Ready(Err(err))
     }
+}
 
-    /// Polls the state of the listener, advancing to the next state if possible.
-    fn poll_state(&mut self, cx: &mut Context<'_>) -> ListenerState {
-        self.state.poll(cx)
+impl AsRawSock for TcpListenerSocket {
+    fn as_raw_sock(&self) -> *mut spdk_sock {
+        self.sock
     }
 }
 
-impl Drop for TcpListenerInner {
+impl Polled for TcpListenerSocket {
+    fn poll(mut self: Pin<&mut Self>) -> bool {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+            return true;
+        }
+
+        false
+    }
+}
+
+impl Drop for TcpListenerSocket {
     fn drop(&mut self) {
         let res = to_result! {
             unsafe { spdk_sock_close(&mut self.sock as *mut _) }
@@ -163,17 +150,38 @@ impl Drop for TcpListenerInner {
     }
 }
 
-impl Polled for TcpListenerInner {
-    fn poll(mut self: Pin<&mut Self>) -> bool {
-        if let Poll::Ready(res) = self.poll_accept() {
-            if let ListenerState::Waiting(waker) = self.state.set_available(res) {
-                waker.wake();
-            }
+#[derive(Debug)]
+pub(crate) struct RawTcpListenerVtable {
+    pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
+    pub(crate) poll_accept: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<Accepted, Errno>>,
+    pub(crate) drop: unsafe fn(*const ()),
+}
 
-            return true;
-        }
+#[derive(Debug)]
+pub(crate) struct RawTcpListener {
+    data: *const (),
+    vtable: &'static RawTcpListenerVtable,
+}
 
-        false
+impl RawTcpListener {
+    pub(crate) fn new(data: *const (), vtable: &'static RawTcpListenerVtable) -> Self {
+        Self { data, vtable }
+    }
+
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+        unsafe { (self.vtable.poll_accept)(self.data, cx) }
+    }
+}
+
+impl AsRawSock for RawTcpListener {
+    fn as_raw_sock(&self) -> *mut spdk_sock {
+        unsafe { (self.vtable.as_raw_sock)(self.data) }
+    }
+}
+
+impl Drop for RawTcpListener {
+    fn drop(&mut self) {
+        unsafe { (self.vtable.drop)(self.data) };
     }
 }
 
@@ -188,29 +196,9 @@ impl Polled for TcpListenerInner {
 /// [`incoming`]: TcpListener::incoming
 /// [`TcpStream`]: super::TcpStream
 #[derive(Debug)]
-pub struct TcpListener(Poller<TcpListenerInner>);
+pub struct TcpListener(RawTcpListener);
 
 impl TcpListener {
-    /// Returns a mutable reference to the inner listener state.
-    fn inner_mut(&mut self) -> &mut TcpListenerInner {
-        self.0.polled_mut()
-    }
-
-    /// Attempts to bind a listener to the specified socket address.
-    fn bind_one(addr: SocketAddr) -> Option<Self> {
-        let raw_sock =
-            unsafe { spdk_sock_listen(addr.ip().as_ptr(), addr.port() as i32, ptr::null()) };
-
-        if !raw_sock.is_null() {
-            return Some(Self(Poller::new(TcpListenerInner {
-                sock: raw_sock,
-                state: ListenerState::Idle,
-            })));
-        }
-
-        None
-    }
-
     /// Creates a new [`TcpListener`] bound to the specified socket address.
     ///
     /// If the port number of the socket address is omitted or `0`, the operating system will assign
@@ -222,7 +210,7 @@ impl TcpListener {
     /// returned.
     pub async fn bind<A: ToSocketAddrs>(addrs: A) -> Result<Self, errors::Errno> {
         for addr in addrs.to_socket_addr().await? {
-            match Self::bind_one(addr) {
+            match bind_polled_listener(addr).map(TcpListener).ok() {
                 Some(listener) => return Ok(listener),
                 None => continue,
             }
@@ -266,13 +254,13 @@ impl TcpListener {
     /// [`accept`]: TcpListener::accept
     /// [`Thread`]: crate::thread::Thread
     pub fn incoming(&mut self) -> Incoming<'_> {
-        Incoming::new(self.inner_mut())
+        Incoming::new(&mut self.0)
     }
 }
 
 impl AsRawSock for TcpListener {
     fn as_raw_sock(&self) -> *mut spdk_sock {
-        self.0.polled().sock
+        self.0.as_raw_sock()
     }
 }
 

--- a/spdk/src/net/listener.rs
+++ b/spdk/src/net/listener.rs
@@ -1,4 +1,6 @@
+//! The implementation of a TCP socket server.
 use std::{
+    mem::ManuallyDrop,
     pin::Pin,
     ptr,
     task::{Context, Poll, Waker},
@@ -9,12 +11,14 @@ use spdk_sys::{spdk_sock, spdk_sock_accept, spdk_sock_close, spdk_sock_listen};
 
 use crate::{
     errors::{self, EAGAIN, EBADF, EINVAL, Errno, errno},
+    net::accept_polled_stream,
     task::Polled,
     to_result,
 };
 
 use super::{
-    AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs, bind_polled_listener,
+    AsRawSock, SocketAddr, SocketGroupEvent, TcpSocketExt, TcpSocketRemote, TcpStream,
+    TcpStreamSocket, ToSocketAddrs, bind_polled_listener,
 };
 
 /// An iterator created by calling the [`TcpListener::incoming()`] method that infinitely accepts
@@ -53,15 +57,42 @@ impl<'a> Stream for Incoming<'a> {
 
 /// Wraps a TCP socket connection accepted by a [`TcpListener`].
 ///
-/// This is an intermediary type returned by the [`TcpListener::accept`] method and iterator
+/// This is an intermediate type returned by the [`TcpListener::accept`] method and iterator
 /// returned by the [`TcpListener::incoming`] method. It enables connected sockets to be sent to
 /// another [`Thread`]. See the [`TcpListener::accept`] method for more information.
 ///
 /// [`Thread`]: crate::thread::Thread
 #[derive(Debug)]
-pub struct Accepted(pub(crate) *mut spdk_sock);
+pub struct Accepted(*mut spdk_sock);
 
 unsafe impl Send for Accepted {}
+
+impl Accepted {
+    /// Creates a new [`Accepted`] instance for the incoming connection specified by `sock`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `spdk_sock` specified in `sock` is a valid, non-null
+    /// incoming socket returned by the [`spdk_sock_accept`] function.
+    pub(crate) unsafe fn new(sock: *mut spdk_sock) -> Self {
+        debug_assert!(!sock.is_null());
+
+        Self(sock)
+    }
+
+    /// Consumes the `Accepted` instance and converts it into a [`TcpStream`] with a
+    /// [`Poller`]-based implementation.
+    ///
+    /// [`Poller`]: crate::task::Poller
+    pub fn into_stream(self) -> TcpStream {
+        accept_polled_stream(self)
+    }
+
+    /// Consumes the `Accepted` instance and converts it into a [`TcpStreamSocket`].
+    pub(crate) fn into_socket(self) -> TcpStreamSocket {
+        TcpStreamSocket::new(ManuallyDrop::new(self).0)
+    }
+}
 
 impl Drop for Accepted {
     fn drop(&mut self) {
@@ -84,13 +115,18 @@ impl TcpSocketExt for Accepted {}
 
 impl TcpSocketRemote for Accepted {}
 
+/// The internal socket implementation for a [`TcpListener`].
 #[derive(Debug)]
 pub(crate) struct TcpListenerSocket {
+    /// A pointer to an `spdk_sock` returned by the [`spdk_sock_listen`] function.
     sock: *mut spdk_sock,
+
+    /// The [`Waker`] awaiting an incoming connection.
     waker: Option<Waker>,
 }
 
 impl TcpListenerSocket {
+    /// Creates a new [`TcpListenerSocket`] bound to the specified socket address.
     pub(crate) fn bind(addr: SocketAddr) -> Result<Self, Errno> {
         let sock = unsafe { spdk_sock_listen(addr.ip().as_ptr(), addr.port() as i32, ptr::null()) };
 
@@ -101,6 +137,12 @@ impl TcpListenerSocket {
         Err(EINVAL)
     }
 
+    /// Polls for incoming connection.
+    ///
+    /// # Returns
+    ///
+    /// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
+    /// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a [`TcpStream`].
     pub(crate) fn poll_accept(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -108,7 +150,7 @@ impl TcpListenerSocket {
         let accepted = unsafe { spdk_sock_accept(self.sock) };
 
         if !accepted.is_null() {
-            return Poll::Ready(Ok(Accepted(accepted)));
+            return Poll::Ready(Ok(unsafe { Accepted::new(accepted) }));
         }
 
         let err = errno();
@@ -125,6 +167,14 @@ impl TcpListenerSocket {
 impl AsRawSock for TcpListenerSocket {
     fn as_raw_sock(&self) -> *mut spdk_sock {
         self.sock
+    }
+}
+
+impl SocketGroupEvent for TcpListenerSocket {
+    fn handle_event(mut self: Pin<&mut Self>) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
     }
 }
 
@@ -150,13 +200,21 @@ impl Drop for TcpListenerSocket {
     }
 }
 
+/// A virtual function pointer table (vtable) that specifies the methods that can be invoked on a
+/// [`RawTcpListener`] instance.
 #[derive(Debug)]
 pub(crate) struct RawTcpListenerVtable {
+    /// Returns the [`RawTcpListener`]'s raw `spdk_sock` pointer.
     pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
+
+    /// Polls the [`RawTcpListener`] for an incoming connection.
     pub(crate) poll_accept: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<Accepted, Errno>>,
+
+    /// Drops the [`RawTcpListener`].
     pub(crate) drop: unsafe fn(*const ()),
 }
 
+/// Enables dynamic dispatch to a TCP socket listener implementation.
 #[derive(Debug)]
 pub(crate) struct RawTcpListener {
     data: *const (),
@@ -164,10 +222,21 @@ pub(crate) struct RawTcpListener {
 }
 
 impl RawTcpListener {
-    pub(crate) fn new(data: *const (), vtable: &'static RawTcpListenerVtable) -> Self {
+    /// Creates a new `RawTcpListener` instance with the specified virtual function table.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `vtable` is correct for the `data` pointer.
+    pub(crate) unsafe fn new(data: *const (), vtable: &'static RawTcpListenerVtable) -> Self {
         Self { data, vtable }
     }
 
+    /// Polls for an incoming connection.
+    ///
+    /// # Returns
+    ///
+    /// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
+    /// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a [`TcpStream`].
     fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
         unsafe { (self.vtable.poll_accept)(self.data, cx) }
     }
@@ -199,6 +268,10 @@ impl Drop for RawTcpListener {
 pub struct TcpListener(RawTcpListener);
 
 impl TcpListener {
+    pub(crate) fn new(listener: RawTcpListener) -> Self {
+        TcpListener(listener)
+    }
+
     /// Creates a new [`TcpListener`] bound to the specified socket address.
     ///
     /// If the port number of the socket address is omitted or `0`, the operating system will assign
@@ -210,7 +283,7 @@ impl TcpListener {
     /// returned.
     pub async fn bind<A: ToSocketAddrs>(addrs: A) -> Result<Self, errors::Errno> {
         for addr in addrs.to_socket_addr().await? {
-            match bind_polled_listener(addr).map(TcpListener).ok() {
+            match bind_polled_listener(addr).ok() {
                 Some(listener) => return Ok(listener),
                 None => continue,
             }
@@ -224,17 +297,18 @@ impl TcpListener {
     /// Since a [`TcpStream`] is bound to the [`Thread`] on which is was created, `accept` returns
     /// an [`Accepted`] intermediate type that is [`Send`]. This allows the connected socket to be
     /// sent to another thread for use. To convert the `Accepted` instance into a `TcpStream`, use
-    /// [`into`].
+    /// the [`Accepted::into_stream`] or [`SocketGroup::add`] methods.
     ///
     /// # Example
     ///
     /// ```no_run
     /// use spdk::net::{TcpListener, TcpStream};
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").await.expect("listener bound");
-    /// let remote: TcpStream = listener.accept().await.expect("remote connected").into();
+    /// let listener = TcpListener::bind("127.0.0.1:8080")?;
+    /// let remote = listener.accept().await?.into_stream();
     /// ```
     ///
+    /// [`SocketGroup::add`]: crate::net::SocketGroup::add
     /// [`Thread`]: crate::thread::Thread
     /// [`into`]: std::convert::Into::into
     /// [`TcpStream`]: super::TcpStream

--- a/spdk/src/net/mod.rs
+++ b/spdk/src/net/mod.rs
@@ -5,17 +5,20 @@
 //! using the Storage Performance Development Kit socket library and modules. It also provides
 //! services for converting and resolving socket addresses.
 mod addr;
+mod group;
 mod listener;
 mod polled;
 mod socket;
 mod stream;
 
+pub(crate) use group::SocketGroupEvent;
 pub(crate) use listener::{RawTcpListener, RawTcpListenerVtable, TcpListenerSocket};
-pub(crate) use polled::{bind_polled_listener, connect_polled_stream, new_polled_stream};
+pub(crate) use polled::{accept_polled_stream, bind_polled_listener, connect_polled_stream};
 pub(crate) use socket::AsRawSock;
-pub(crate) use stream::{RawTcpStream, RawTcpStreamVtable, TcpStreamSocket};
+pub(crate) use stream::{Connector, RawTcpStream, RawTcpStreamVtable, TcpStreamSocket};
 
 pub use addr::{SocketAddr, SocketAddrIter, ToSocketAddrs, resolve};
+pub use group::SocketGroup;
 pub use listener::{Accepted, Incoming, TcpListener};
 pub use socket::{TcpSocketExt, TcpSocketRemote};
 #[allow(unused_imports)]

--- a/spdk/src/net/mod.rs
+++ b/spdk/src/net/mod.rs
@@ -6,12 +6,17 @@
 //! services for converting and resolving socket addresses.
 mod addr;
 mod listener;
+mod polled;
 mod socket;
 mod stream;
 
+pub(crate) use listener::{RawTcpListener, RawTcpListenerVtable, TcpListenerSocket};
+pub(crate) use polled::{bind_polled_listener, connect_polled_stream, new_polled_stream};
+pub(crate) use socket::AsRawSock;
+pub(crate) use stream::{RawTcpStream, RawTcpStreamVtable, TcpStreamSocket};
+
 pub use addr::{SocketAddr, SocketAddrIter, ToSocketAddrs, resolve};
 pub use listener::{Accepted, Incoming, TcpListener};
-pub(crate) use socket::AsRawSock;
 pub use socket::{TcpSocketExt, TcpSocketRemote};
 #[allow(unused_imports)]
 use spdk_sys::spdk_sock;

--- a/spdk/src/net/polled.rs
+++ b/spdk/src/net/polled.rs
@@ -1,3 +1,4 @@
+//! Contains the SPDK poller based TCP listener and stream implementations.
 use std::{
     mem::ManuallyDrop,
     pin::Pin,
@@ -9,10 +10,14 @@ use spdk_sys::{spdk_sock, spdk_sock_opts};
 use crate::{errors::Errno, task::Poller};
 
 use super::{
-    Accepted, AsRawSock, RawTcpListener, RawTcpListenerVtable, RawTcpStream, RawTcpStreamVtable,
-    SocketAddr, TcpListenerSocket, TcpStreamSocket,
+    Accepted, AsRawSock, Connector, RawTcpListener, RawTcpListenerVtable, RawTcpStream,
+    RawTcpStreamVtable, SocketAddr, TcpListener, TcpListenerSocket, TcpStream, TcpStreamSocket,
 };
 
+/// Returns the [`RawTcpListener`]'s raw `spdk_sock` pointer.
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpListenerSocket`]`>` instance.
 fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
     let this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
@@ -20,6 +25,16 @@ fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
     this.polled().as_raw_sock()
 }
 
+/// Polls the [`RawTcpListener`] for an incoming connection.
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpListenerSocket`]`>` instance.
+///
+/// # Returns
+///
+/// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
+/// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a
+/// [`TcpStream`].
 fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
@@ -27,10 +42,18 @@ fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Ac
     Pin::new(this.polled_mut()).poll_accept(cx)
 }
 
+/// Drops the [`RawTcpListener`].
+///
+/// This function is invoked through the [`RawTcpListenerVtable`] created by the [`listener_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpListenerSocket`]`>` instance.
 fn listener_drop(data: *const ()) {
     drop(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
 }
 
+/// Returns the [`RawTcpListenerVtable`] used by a [`RawTcpListener`].
+///
+/// This virtual function table enables dynamic dispatch to a [`Poller`]`<`[`TcpListenerSocket`]`>`
+/// instance.
 fn listener_vtable() -> &'static RawTcpListenerVtable {
     &RawTcpListenerVtable {
         as_raw_sock: listener_as_raw_sock,
@@ -39,15 +62,26 @@ fn listener_vtable() -> &'static RawTcpListenerVtable {
     }
 }
 
-pub(crate) fn bind_polled_listener(addr: SocketAddr) -> Result<RawTcpListener, Errno> {
+/// Creates a new [`TcpListener`] bound to the specified socket address.
+///
+/// If the port number of the socket address is omitted or `0`, the operating system will assign
+/// a port to this listener. The allocated port can be discovered by calling the
+/// [`TcpSocketExt::local_addr()`] method.
+///
+/// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
+pub(crate) fn bind_polled_listener(addr: SocketAddr) -> Result<TcpListener, Errno> {
     let listener = Poller::new(TcpListenerSocket::bind(addr)?);
 
-    Ok(RawTcpListener::new(
-        Poller::into_raw(listener).cast(),
-        listener_vtable(),
-    ))
+    // SAFETY: The `vtable` matches the `data` pointer type.
+    Ok(TcpListener::new(unsafe {
+        RawTcpListener::new(Poller::into_raw(listener).cast(), listener_vtable())
+    }))
 }
 
+/// Returns the [`RawTcpStream`]'s raw `spdk_sock` pointer.
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
 fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
     let this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
@@ -55,6 +89,15 @@ fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
     this.polled().as_raw_sock()
 }
 
+/// Polls the connection state of the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
+/// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
 fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
@@ -62,6 +105,17 @@ fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(
     Pin::new(this.polled_mut()).poll_connected(cx)
 }
 
+/// Attempts to read from the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns number of bytes read in `Poll::Ready(Ok(num_bytes_read))` if data was
+/// available and `Poll::Pending` if no data was available.
+///
+/// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
 fn stream_poll_read(
     data: *const (),
     cx: &mut Context<'_>,
@@ -73,6 +127,17 @@ fn stream_poll_read(
     Pin::new(this.polled_mut()).poll_read(cx, buf)
 }
 
+/// Attempts to write to the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns number of bytes written in `Poll::Ready(Ok(num_bytes_written))` if data was
+/// written and `Poll::Pending` data cannot currently be written.
+///
+/// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
 fn stream_poll_write(
     data: *const (),
     cx: &mut Context<'_>,
@@ -84,6 +149,15 @@ fn stream_poll_write(
     Pin::new(this.polled_mut()).poll_write(cx, buf)
 }
 
+/// Attempts to flush buffered data from the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this method
+/// always returns `Poll::Ready(Ok())`.
 fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
@@ -91,6 +165,15 @@ fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), E
     Pin::new(this.polled_mut()).poll_flush(cx)
 }
 
+/// Attempts to close the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
+///
+/// # Returns
+///
+/// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
+/// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
 fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
@@ -98,10 +181,18 @@ fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), E
     Pin::new(this.polled_mut()).poll_close(cx)
 }
 
+/// Drops the [`RawTcpStream`].
+///
+/// This function is invoked through the [`RawTcpStreamVtable`] crated by the [`stream_vtable`]
+/// function. It enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>` instance.
 fn stream_drop(data: *const ()) {
     drop(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 }
 
+/// Returns the [`RawTcpStreamVtable`] used by a [`RawTcpStream`].
+///
+/// This virtual function table enables dynamic dispatch to a [`Poller`]`<`[`TcpStreamSocket`]`>`
+/// instance.
 fn stream_vtable() -> &'static RawTcpStreamVtable {
     &RawTcpStreamVtable {
         as_raw_sock: stream_as_raw_sock,
@@ -114,16 +205,24 @@ fn stream_vtable() -> &'static RawTcpStreamVtable {
     }
 }
 
-pub(crate) fn connect_polled_stream(addr: SocketAddr, opts: &spdk_sock_opts) -> RawTcpStream {
+/// Accepts a new incoming connection producing a [`TcpStream`].
+pub(crate) fn accept_polled_stream(accepted: Accepted) -> TcpStream {
+    let stream = Poller::new(accepted.into_socket());
+
+    // SAFETY: The `vtable` matches the `data` pointer type.
+    TcpStream::new(unsafe { RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable()) })
+}
+
+/// Creates a [`TcpStream`] connected to the specified socket address.
+pub(crate) async fn connect_polled_stream(
+    addr: SocketAddr,
+    opts: &spdk_sock_opts,
+) -> Result<TcpStream, Errno> {
     let stream = Poller::new_in_place(|stream| {
         TcpStreamSocket::connect_in_place(stream, addr, opts);
     });
 
-    RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable())
-}
-
-pub(crate) fn new_polled_stream(sock: *mut spdk_sock) -> RawTcpStream {
-    let stream = Poller::new(TcpStreamSocket::new(sock));
-
-    RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable())
+    // SAFETY: The `vtable` matches the `data` pointer type.
+    Connector::new(unsafe { RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable()) })
+        .await
 }

--- a/spdk/src/net/polled.rs
+++ b/spdk/src/net/polled.rs
@@ -1,0 +1,129 @@
+use std::{
+    mem::ManuallyDrop,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use spdk_sys::{spdk_sock, spdk_sock_opts};
+
+use crate::{errors::Errno, task::Poller};
+
+use super::{
+    Accepted, AsRawSock, RawTcpListener, RawTcpListenerVtable, RawTcpStream, RawTcpStreamVtable,
+    SocketAddr, TcpListenerSocket, TcpStreamSocket,
+};
+
+fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
+    let this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
+
+    this.polled().as_raw_sock()
+}
+
+fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
+
+    Pin::new(this.polled_mut()).poll_accept(cx)
+}
+
+fn listener_drop(data: *const ()) {
+    drop(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
+}
+
+fn listener_vtable() -> &'static RawTcpListenerVtable {
+    &RawTcpListenerVtable {
+        as_raw_sock: listener_as_raw_sock,
+        poll_accept: listener_poll_accept,
+        drop: listener_drop,
+    }
+}
+
+pub(crate) fn bind_polled_listener(addr: SocketAddr) -> Result<RawTcpListener, Errno> {
+    let listener = Poller::new(TcpListenerSocket::bind(addr)?);
+
+    Ok(RawTcpListener::new(
+        Poller::into_raw(listener).cast(),
+        listener_vtable(),
+    ))
+}
+
+fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
+    let this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    this.polled().as_raw_sock()
+}
+
+fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    Pin::new(this.polled_mut()).poll_connected(cx)
+}
+
+fn stream_poll_read(
+    data: *const (),
+    cx: &mut Context<'_>,
+    buf: &mut [u8],
+) -> Poll<Result<usize, Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    Pin::new(this.polled_mut()).poll_read(cx, buf)
+}
+
+fn stream_poll_write(
+    data: *const (),
+    cx: &mut Context<'_>,
+    buf: &[u8],
+) -> Poll<Result<usize, Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    Pin::new(this.polled_mut()).poll_write(cx, buf)
+}
+
+fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    Pin::new(this.polled_mut()).poll_flush(cx)
+}
+
+fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    let mut this =
+        ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+
+    Pin::new(this.polled_mut()).poll_close(cx)
+}
+
+fn stream_drop(data: *const ()) {
+    drop(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
+}
+
+fn stream_vtable() -> &'static RawTcpStreamVtable {
+    &RawTcpStreamVtable {
+        as_raw_sock: stream_as_raw_sock,
+        poll_connected: stream_poll_connected,
+        poll_read: stream_poll_read,
+        poll_write: stream_poll_write,
+        poll_flush: stream_poll_flush,
+        poll_close: stream_poll_close,
+        drop: stream_drop,
+    }
+}
+
+pub(crate) fn connect_polled_stream(addr: SocketAddr, opts: &spdk_sock_opts) -> RawTcpStream {
+    let stream = Poller::new_in_place(|stream| {
+        TcpStreamSocket::connect_in_place(stream, addr, opts);
+    });
+
+    RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable())
+}
+
+pub(crate) fn new_polled_stream(sock: *mut spdk_sock) -> RawTcpStream {
+    let stream = Poller::new(TcpStreamSocket::new(sock));
+
+    RawTcpStream::new(Poller::into_raw(stream).cast(), stream_vtable())
+}

--- a/spdk/src/net/socket.rs
+++ b/spdk/src/net/socket.rs
@@ -5,7 +5,9 @@ use std::{
 
 use spdk_sys::{spdk_sock, spdk_sock_getaddr};
 
-use crate::{errors::Errno, net::SocketAddr, to_result};
+use crate::{errors::Errno, to_result};
+
+use super::SocketAddr;
 
 /// A trait providing access to the raw `spdk_sock` pointer.
 pub(crate) trait AsRawSock {

--- a/spdk/src/net/socket.rs
+++ b/spdk/src/net/socket.rs
@@ -1,5 +1,7 @@
+//! Common operations that can be performed on TCP listeners and streams.
 use std::{
     ffi::CStr,
+    mem::MaybeUninit,
     ptr::{self, addr_of_mut},
 };
 
@@ -11,7 +13,17 @@ use super::SocketAddr;
 
 /// A trait providing access to the raw `spdk_sock` pointer.
 pub(crate) trait AsRawSock {
+    /// Returns the socket's raw `spdk_sock` pointer.
     fn as_raw_sock(&self) -> *mut spdk_sock;
+}
+
+impl<T> AsRawSock for MaybeUninit<T>
+where
+    T: AsRawSock,
+{
+    fn as_raw_sock(&self) -> *mut spdk_sock {
+        unreachable!("as_raw_sock called on uninitialized data");
+    }
 }
 
 /// A trait defining methods common to TCP sockets.

--- a/spdk/src/net/stream.rs
+++ b/spdk/src/net/stream.rs
@@ -133,6 +133,44 @@ struct TcpStreamInner {
 }
 
 impl TcpStreamInner {
+    /// A callback function invoked when the connection operation is complete.
+    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, status: i32) {
+        let inner = unsafe { &mut *(cb_arg as *mut TcpStreamInner) };
+
+        match to_result!(status) {
+            Ok(_) => inner.state.set_connected(),
+            Err(e) => inner.state.set_failed(e),
+        };
+    }
+
+    /// Creates a TCP connection to the specified socket address, initializing the internal state of
+    /// a [`TcpStream`} in-place.
+    fn connect_in_place(
+        this: Pin<&mut MaybeUninit<TcpStreamInner>>,
+        addr: SocketAddr,
+        opts: &spdk_sock_opts,
+    ) {
+        let this = this.get_mut().write(TcpStreamInner {
+            sock: ptr::null_mut(),
+            state: StreamState::Connecting(None),
+        });
+
+        this.sock = unsafe {
+            spdk_sock_connect_async(
+                addr.ip().as_ptr(),
+                addr.port().into(),
+                ptr::null_mut(),
+                opts as *const _ as *mut _,
+                Some(Self::connect_complete),
+                this as *mut _ as *mut _,
+            )
+        };
+
+        if this.sock.is_null() {
+            this.state = StreamState::Failed(EINVAL);
+        }
+    }
+
     /// Polls the state of the stream.
     ///
     /// # Returns
@@ -140,6 +178,68 @@ impl TcpStreamInner {
     /// Returns `true` if a waiting [`Waker`] was awakened; `false` otherwise.
     fn poll_state(&mut self) -> bool {
         self.state.poll()
+    }
+
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let res = to_result_size! {
+            unsafe { spdk_sock_recv(self.sock, addr_of_mut!(*buf) as *mut _, buf.len()) }
+        };
+
+        match res {
+            Ok(s) => Poll::Ready(Ok(s)),
+            Err(EAGAIN) => {
+                if let StreamState::Connected(waker) = &mut self.state {
+                    *waker = Some(cx.waker().clone());
+                    return Poll::Pending;
+                }
+
+                unreachable!("poll_read called in unexpected state: {:?}", self.state);
+            }
+            Err(e) => Poll::Ready(Err(e.into())),
+        }
+    }
+
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let iov = IoSlice::new(buf);
+        let res = to_result_size! {
+            unsafe { spdk_sock_writev(self.sock, addr_of!(iov) as *mut IoVec, 1) }
+        };
+
+        match res {
+            Ok(s) => Poll::Ready(Ok(s)),
+            Err(EAGAIN) => {
+                if let StreamState::Connected(waker) = &mut self.state {
+                    *waker = Some(cx.waker().clone());
+                    return Poll::Pending;
+                }
+
+                unreachable!("poll_write called in unexpected state: {:?}", self.state);
+            }
+            Err(e) => Poll::Ready(Err(e.into())),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let res = to_result! {
+            unsafe { spdk_sock_close(&mut self.sock as *mut _) }
+        };
+
+        match res {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(e) => Poll::Ready(Err(e.into())),
+        }
     }
 }
 
@@ -184,38 +284,10 @@ impl TcpStream {
         self.0.polled_mut()
     }
 
-    /// A callback function invoked when the connection operation is complete.
-    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, status: i32) {
-        let inner = unsafe { &mut *(cb_arg as *mut TcpStreamInner) };
-
-        match to_result!(status) {
-            Ok(_) => inner.state.set_connected(),
-            Err(e) => inner.state.set_failed(e),
-        };
-    }
-
     /// Attempts to connect a stream to the specified socket address.
     async fn connect_one(addr: SocketAddr, opts: &spdk_sock_opts) -> Result<Self, Errno> {
-        Connector(Some(TcpStream(Poller::new_in_place(move |inner| {
-            let inner = inner.get_mut().write(TcpStreamInner {
-                sock: ptr::null_mut(),
-                state: StreamState::Connecting(None),
-            });
-
-            inner.sock = unsafe {
-                spdk_sock_connect_async(
-                    addr.ip().as_ptr(),
-                    addr.port().into(),
-                    ptr::null_mut(),
-                    opts as *const _ as *mut _,
-                    Some(Self::connect_complete),
-                    inner as *mut _ as *mut _,
-                )
-            };
-
-            if inner.sock.is_null() {
-                inner.state = StreamState::Failed(EINVAL);
-            }
+        Connector(Some(TcpStream(Poller::new_in_place(|inner| {
+            TcpStreamInner::connect_in_place(inner, addr, opts)
         }))))
         .await
     }
@@ -260,25 +332,7 @@ impl AsyncRead for TcpStream {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        let res = to_result_size! {
-            unsafe { spdk_sock_recv(self.inner().sock, addr_of_mut!(*buf) as *mut _, buf.len()) }
-        };
-
-        match res {
-            Ok(s) => Poll::Ready(Ok(s)),
-            Err(EAGAIN) => {
-                if let StreamState::Connected(waker) = &mut self.inner_mut().state {
-                    *waker = Some(cx.waker().clone());
-                    return Poll::Pending;
-                }
-
-                unreachable!(
-                    "poll_read called in unexpected state: {:?}",
-                    self.inner().state
-                );
-            }
-            Err(e) => Poll::Ready(Err(e.into())),
-        }
+        Pin::new(self.inner_mut()).poll_read(cx, buf)
     }
 }
 
@@ -288,41 +342,15 @@ impl AsyncWrite for TcpStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        let iov = IoSlice::new(buf);
-        let res = to_result_size! {
-            unsafe { spdk_sock_writev(self.inner().sock, addr_of!(iov) as *mut IoVec, 1) }
-        };
-
-        match res {
-            Ok(s) => Poll::Ready(Ok(s)),
-            Err(EAGAIN) => {
-                if let StreamState::Connected(waker) = &mut self.inner_mut().state {
-                    *waker = Some(cx.waker().clone());
-                    return Poll::Pending;
-                }
-
-                unreachable!(
-                    "poll_write called in unexpected state: {:?}",
-                    self.inner().state
-                );
-            }
-            Err(e) => Poll::Ready(Err(e.into())),
-        }
+        Pin::new(self.inner_mut()).poll_write(cx, buf)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(self.inner_mut()).poll_flush(cx)
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let res = to_result! {
-            unsafe { spdk_sock_close(&mut self.inner_mut().sock as *mut _) }
-        };
-
-        match res {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(e) => Poll::Ready(Err(e.into())),
-        }
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(self.inner_mut()).poll_close(cx)
     }
 }
 

--- a/spdk/src/net/stream.rs
+++ b/spdk/src/net/stream.rs
@@ -1,7 +1,8 @@
+//! The implementation of a TCP connection between local and remote sockets.
 use std::{
     future::Future,
     io::IoSlice,
-    mem::{ManuallyDrop, MaybeUninit},
+    mem::MaybeUninit,
     os::raw::c_void,
     pin::Pin,
     ptr::{self, addr_of, addr_of_mut},
@@ -16,31 +17,42 @@ use spdk_sys::{
 };
 
 use crate::{
-    errors::{EAGAIN, EBADF, EINVAL, Errno},
+    errors::{EAGAIN, EBADF, EINPROGRESS, EINVAL, Errno, SUCCESS},
     task::Polled,
     to_result, to_result_size,
 };
 
 use super::{
-    Accepted, AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs,
-    connect_polled_stream, new_polled_stream,
+    AsRawSock, SocketAddr, SocketGroupEvent, TcpSocketExt, TcpSocketRemote, ToSocketAddrs,
+    connect_polled_stream,
 };
 
 /// A future implementation for awaiting the connection of a [`TcpStream`].
 #[derive(Debug)]
-struct Connector(Option<RawTcpStream>);
+pub(crate) struct Connector(Option<RawTcpStream>);
 
 impl Connector {
+    /// Creates a new `Connector` instance for specified [`TcpStream`].
+    pub(crate) fn new(stream: RawTcpStream) -> Self {
+        Self(Some(stream))
+    }
+
     /// Polls the connection state of the stream.
+    ///
+    /// # Returns
+    ///
+    /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
+    /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
     fn poll_connected(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<TcpStream, Errno>> {
+    ) -> Poll<Result<RawTcpStream, Errno>> {
+        // SAFETY: We're mapping to a field of a pinned object.
         unsafe { Pin::map_unchecked_mut(self.as_mut(), |s| &mut s.0) }
             .as_pin_mut()
-            .map(|stream| RawTcpStream::poll_connected(stream, cx))
+            .map(|stream| stream.poll_connected(cx))
             .unwrap_or(Poll::Ready(Err(EBADF)))
-            .map_ok(|_| TcpStream(self.0.take().unwrap()))
+            .map_ok(|_| self.0.take().unwrap())
     }
 }
 
@@ -48,32 +60,51 @@ impl Future for Connector {
     type Output = Result<TcpStream, Errno>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.poll_connected(cx)
+        self.poll_connected(cx).map_ok(TcpStream::new)
     }
 }
 
+/// The internal socket implementation for a [`TcpStream`].
 #[derive(Debug)]
 pub(crate) struct TcpStreamSocket {
+    /// A pointer to an `spdk_sock` returned by the [`spdk_sock_connect_async`] or [`spdk_sock_accept`] functions.
+    ///
+    /// [`spdk_sock_accept`]: spdk_sys::spdk_sock_accept
     sock: *mut spdk_sock,
+
+    /// The [`Waker`] awaiting an I/O operation.
     waker: Option<Waker>,
+
+    /// The connection status.
+    conn_status: Errno,
 }
 
 impl TcpStreamSocket {
+    /// Creates a new `TcpStreamSocket` instance from an `spdk_sock` returned by the
+    /// [`spdk_sock_connect_async`] or [`spdk_sock_accept`] functions.
+    ///
+    /// [`spdk_sock_accept`]: spdk_sys::spdk_sock_accept
     pub(crate) fn new(sock: *mut spdk_sock) -> Self {
-        Self { sock, waker: None }
+        Self {
+            sock,
+            waker: None,
+            conn_status: SUCCESS,
+        }
     }
 
     /// A callback function invoked when the connection operation is complete.
-    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, _status: i32) {
+    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, status: i32) {
         let inner = unsafe { &mut *(cb_arg as *mut TcpStreamSocket) };
+
+        inner.conn_status = Errno::new(-status);
 
         if let Some(waker) = inner.waker.take() {
             waker.wake();
         }
     }
 
-    /// Creates a TCP connection to the specified socket address, initializing the internal state of
-    /// a [`TcpStreamSocket`} in-place.
+    /// Creates a TCP connection to the specified socket address, initializing the
+    /// [`TcpStreamSocket`] in-place.
     pub(crate) fn connect_in_place(
         this: Pin<&mut MaybeUninit<TcpStreamSocket>>,
         addr: SocketAddr,
@@ -82,6 +113,7 @@ impl TcpStreamSocket {
         let this = this.get_mut().write(TcpStreamSocket {
             sock: ptr::null_mut(),
             waker: None,
+            conn_status: EINPROGRESS,
         });
 
         this.sock = unsafe {
@@ -96,10 +128,18 @@ impl TcpStreamSocket {
         };
     }
 
+    /// Polls the connection state of the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
+    /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
     pub(crate) fn poll_connected(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Errno>> {
+        // Call `spdk_sock_flush` to get an indication whether the connection is in-progress,
+        // complete or failed.
         let res = to_result!(unsafe { spdk_sock_flush(self.sock) });
 
         match res {
@@ -108,10 +148,18 @@ impl TcpStreamSocket {
                 self.waker = Some(cx.waker().clone());
                 Poll::Pending
             }
-            Err(e) => Poll::Ready(Err(e)),
+            Err(_) => Poll::Ready(Err(self.conn_status)),
         }
     }
 
+    /// Attempts to read from the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// This method returns number of bytes read in `Poll::Ready(Ok(num_bytes_read))` if data was
+    /// available and `Poll::Pending` if no data was available.
+    ///
+    /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
     pub(crate) fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -131,6 +179,14 @@ impl TcpStreamSocket {
         }
     }
 
+    /// Attempts to write to the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// This method returns number of bytes written in `Poll::Ready(Ok(num_bytes_written))` if data was
+    /// written and `Poll::Pending` data cannot currently be written.
+    ///
+    /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
     pub(crate) fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -150,6 +206,12 @@ impl TcpStreamSocket {
         }
     }
 
+    /// Attempts to flush buffered data from the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this
+    /// method always returns `Poll::Ready(Ok())`.
     pub(crate) fn poll_flush(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -157,6 +219,12 @@ impl TcpStreamSocket {
         Poll::Ready(Ok(()))
     }
 
+    /// Attempts to close the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
+    /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
     pub(crate) fn poll_close(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -170,6 +238,14 @@ impl TcpStreamSocket {
 impl AsRawSock for TcpStreamSocket {
     fn as_raw_sock(&self) -> *mut spdk_sock {
         self.sock
+    }
+}
+
+impl SocketGroupEvent for TcpStreamSocket {
+    fn handle_event(mut self: Pin<&mut Self>) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
     }
 }
 
@@ -195,21 +271,37 @@ impl Drop for TcpStreamSocket {
     }
 }
 
+/// A virtual function pointer table (vtable) that specifies the methods that can be invoked on a
+/// [`RawTcpStream`] instance.
 #[derive(Debug)]
 pub(crate) struct RawTcpStreamVtable {
+    /// Returns the [`RawTcpStream`]'s raw `spdk_sock` pointer.
     pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
+
+    /// Polls the connection state of the [`RawTcpStream`].
     pub(crate) poll_connected: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+
+    /// Attempts to read from the [`RawTcpStream`].
     #[allow(clippy::type_complexity)]
     pub(crate) poll_read:
         unsafe fn(*const (), &mut Context<'_>, &mut [u8]) -> Poll<Result<usize, Errno>>,
+
+    /// Attempts to write to the [`RawTcpStream`].
     #[allow(clippy::type_complexity)]
     pub(crate) poll_write:
         unsafe fn(*const (), &mut Context<'_>, &[u8]) -> Poll<Result<usize, Errno>>,
+
+    /// Attempts to flush buffered data in the [`RawTcpStream`].
     pub(crate) poll_flush: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+
+    /// Attempts to close the [`RawTcpStream`].
     pub(crate) poll_close: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+
+    /// Drops the [`RawTcpStream`].
     pub(crate) drop: unsafe fn(*const ()),
 }
 
+/// Enables dynamic dispatch to a TCP socket stream implementation.
 #[derive(Debug)]
 pub(crate) struct RawTcpStream {
     data: *const (),
@@ -217,14 +309,33 @@ pub(crate) struct RawTcpStream {
 }
 
 impl RawTcpStream {
-    pub(crate) fn new(data: *const (), vtable: &'static RawTcpStreamVtable) -> Self {
+    /// Creates a new `RawTcpStream` instance with the specified virtual function table.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `vtable` is correct for the `data` pointer.
+    pub(crate) unsafe fn new(data: *const (), vtable: &'static RawTcpStreamVtable) -> Self {
         Self { data, vtable }
     }
 
+    /// Polls the connection state of the TCP stream.
+    ///
+    /// # Returns
+    ///
+    /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
+    /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
     fn poll_connected(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
         unsafe { (self.vtable.poll_connected)(self.data, cx) }
     }
 
+    /// Attempts to read from the [`TcpStreamSocket`].
+    ///
+    /// # Returns
+    ///
+    /// This method returns number of bytes read in `Poll::Ready(Ok(num_bytes_read))` if data was
+    /// available and `Poll::Pending` if no data was available.
+    ///
+    /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -233,6 +344,14 @@ impl RawTcpStream {
         unsafe { (self.vtable.poll_read)(self.data, cx, buf) }
     }
 
+    /// Attempts to write to the TCP stream.
+    ///
+    /// # Returns
+    ///
+    /// This method returns number of bytes written in `Poll::Ready(Ok(num_bytes_written))` if data was
+    /// written and `Poll::Pending` data cannot currently be written.
+    ///
+    /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -241,10 +360,22 @@ impl RawTcpStream {
         unsafe { (self.vtable.poll_write)(self.data, cx, buf) }
     }
 
+    /// Attempts to flush buffered data from the TCP stream.
+    ///
+    /// # Returns
+    ///
+    /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this
+    /// method always returns `Poll::Ready(Ok())`.
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
         unsafe { (self.vtable.poll_flush)(self.data, cx) }
     }
 
+    /// Attempts to close the TCP stream.
+    ///
+    /// # Returns
+    ///
+    /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
+    /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
         unsafe { (self.vtable.poll_close)(self.data, cx) }
     }
@@ -274,6 +405,10 @@ impl Drop for RawTcpStream {
 pub struct TcpStream(RawTcpStream);
 
 impl TcpStream {
+    pub(crate) fn new(stream: RawTcpStream) -> Self {
+        Self(stream)
+    }
+
     /// Creates a TCP connection to the specified socket address.
     ///
     /// If `addr` yields multiple socket addresses, `connect` will attempt to connect to each until
@@ -292,7 +427,7 @@ impl TcpStream {
         let mut last_err = EINVAL;
 
         for addr in addrs.to_socket_addr().await? {
-            match Connector(Some(connect_polled_stream(addr, &opts))).await {
+            match connect_polled_stream(addr, &opts).await {
                 Ok(stream) => return Ok(stream),
                 Err(e) => last_err = e,
             }
@@ -347,13 +482,3 @@ impl AsRawSock for TcpStream {
 impl TcpSocketExt for TcpStream {}
 
 impl TcpSocketRemote for TcpStream {}
-
-impl From<Accepted> for TcpStream {
-    fn from(value: Accepted) -> Self {
-        let value = ManuallyDrop::new(value);
-
-        assert!(!value.0.is_null());
-
-        Self(new_polled_stream(value.0))
-    }
-}

--- a/spdk/src/net/stream.rs
+++ b/spdk/src/net/stream.rs
@@ -1,7 +1,7 @@
 use std::{
     future::Future,
     io::IoSlice,
-    mem::{self, ManuallyDrop, MaybeUninit},
+    mem::{ManuallyDrop, MaybeUninit},
     os::raw::c_void,
     pin::Pin,
     ptr::{self, addr_of, addr_of_mut},
@@ -10,149 +10,78 @@ use std::{
 
 use futures::{AsyncRead, AsyncWrite};
 use spdk_sys::{
-    iovec as IoVec, spdk_sock, spdk_sock_close, spdk_sock_connect_async,
+    iovec as IoVec, spdk_sock, spdk_sock_close, spdk_sock_connect_async, spdk_sock_flush,
     spdk_sock_get_default_opts, spdk_sock_is_connected, spdk_sock_opts, spdk_sock_recv,
     spdk_sock_writev,
 };
 
 use crate::{
     errors::{EAGAIN, EBADF, EINVAL, Errno},
-    task::{Polled, Poller},
+    task::Polled,
     to_result, to_result_size,
 };
 
-use super::{Accepted, AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs};
-
-/// The state of a [`TcpStream`].
-#[derive(Debug)]
-enum StreamState {
-    /// The stream is connecting. The optional [`Waker`] receives notification of the connection result.
-    Connecting(Option<Waker>),
-
-    /// The stream is connected. The optional [`Waker`] receives notification of read or write
-    /// operation completions.
-    Connected(Option<Waker>),
-
-    /// The stream failed and is no longer functional. The [`Errno`] value describes the reason for
-    /// the failure.
-    Failed(Errno),
-}
-
-impl StreamState {
-    /// Polls the state of the stream.
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if a waiting [`Waker`] was awakened; `false` otherwise.
-    fn poll(&mut self) -> bool {
-        match self {
-            Self::Connecting(maybe_waker) | Self::Connected(maybe_waker) => {
-                if let Some(waker) = maybe_waker.take() {
-                    waker.wake();
-                    return true;
-                }
-
-                false
-            }
-            Self::Failed(_) => false,
-        }
-    }
-
-    /// Sets the state to [`Connected`].
-    ///
-    /// [`Connected`]: Self::Connected
-    fn set_connected(&mut self) {
-        let prev_state = mem::replace(self, Self::Connected(None));
-
-        match prev_state {
-            Self::Connecting(maybe_waker) => {
-                if let Some(waker) = maybe_waker {
-                    waker.wake();
-                }
-            }
-            _ => unreachable!("set_connected called in unexpected state: {:?}", prev_state),
-        }
-    }
-
-    /// Sets the state to [`Failed`].
-    ///
-    /// [`Failed`]: Self::Failed
-    fn set_failed(&mut self, e: Errno) {
-        let mut prev_state = mem::replace(self, Self::Failed(e));
-
-        prev_state.poll();
-    }
-}
+use super::{
+    Accepted, AsRawSock, SocketAddr, TcpSocketExt, TcpSocketRemote, ToSocketAddrs,
+    connect_polled_stream, new_polled_stream,
+};
 
 /// A future implementation for awaiting the connection of a [`TcpStream`].
 #[derive(Debug)]
-struct Connector(Option<TcpStream>);
+struct Connector(Option<RawTcpStream>);
 
 impl Connector {
     /// Polls the connection state of the stream.
-    fn poll_connected(&mut self, _cx: &mut Context<'_>) -> Poll<Result<TcpStream, Errno>> {
-        self.0
-            .as_mut()
-            .map(|stream| {
-                // Poll the `spdk_sock`'s connection state to update its internal state and invoke
-                // the callback passed to `spdk_sock_connect_async` if the connection operation is
-                // complete. The callback will update the internal `TcpStream` state with the result
-                // if invoked.
-                if stream.is_connected() {
-                    assert!(matches!(stream.inner().state, StreamState::Connected(_)));
-                    return Poll::Ready(Ok(()));
-                }
-
-                // If the `spdk_sock` was connected, the result was already returned above. We need
-                // only be concerened with two possibilities now: either the connection is still
-                // pending or it failed.
-                match stream.inner().state {
-                    StreamState::Connecting(_) => Poll::Pending,
-                    StreamState::Failed(e) => Poll::Ready(Err(e)),
-                    StreamState::Connected(_) => unreachable!(),
-                }
-            })
+    fn poll_connected(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<TcpStream, Errno>> {
+        unsafe { Pin::map_unchecked_mut(self.as_mut(), |s| &mut s.0) }
+            .as_pin_mut()
+            .map(|stream| RawTcpStream::poll_connected(stream, cx))
             .unwrap_or(Poll::Ready(Err(EBADF)))
-            .map_ok(|_| self.0.take().unwrap())
+            .map_ok(|_| TcpStream(self.0.take().unwrap()))
     }
 }
 
 impl Future for Connector {
     type Output = Result<TcpStream, Errno>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.poll_connected(cx)
     }
 }
 
-/// The internal state of a [`TcpStream`].
 #[derive(Debug)]
-struct TcpStreamInner {
+pub(crate) struct TcpStreamSocket {
     sock: *mut spdk_sock,
-    state: StreamState,
+    waker: Option<Waker>,
 }
 
-impl TcpStreamInner {
-    /// A callback function invoked when the connection operation is complete.
-    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, status: i32) {
-        let inner = unsafe { &mut *(cb_arg as *mut TcpStreamInner) };
+impl TcpStreamSocket {
+    pub(crate) fn new(sock: *mut spdk_sock) -> Self {
+        Self { sock, waker: None }
+    }
 
-        match to_result!(status) {
-            Ok(_) => inner.state.set_connected(),
-            Err(e) => inner.state.set_failed(e),
-        };
+    /// A callback function invoked when the connection operation is complete.
+    unsafe extern "C" fn connect_complete(cb_arg: *mut c_void, _status: i32) {
+        let inner = unsafe { &mut *(cb_arg as *mut TcpStreamSocket) };
+
+        if let Some(waker) = inner.waker.take() {
+            waker.wake();
+        }
     }
 
     /// Creates a TCP connection to the specified socket address, initializing the internal state of
-    /// a [`TcpStream`} in-place.
-    fn connect_in_place(
-        this: Pin<&mut MaybeUninit<TcpStreamInner>>,
+    /// a [`TcpStreamSocket`} in-place.
+    pub(crate) fn connect_in_place(
+        this: Pin<&mut MaybeUninit<TcpStreamSocket>>,
         addr: SocketAddr,
         opts: &spdk_sock_opts,
     ) {
-        let this = this.get_mut().write(TcpStreamInner {
+        let this = this.get_mut().write(TcpStreamSocket {
             sock: ptr::null_mut(),
-            state: StreamState::Connecting(None),
+            waker: None,
         });
 
         this.sock = unsafe {
@@ -165,85 +94,97 @@ impl TcpStreamInner {
                 this as *mut _ as *mut _,
             )
         };
-
-        if this.sock.is_null() {
-            this.state = StreamState::Failed(EINVAL);
-        }
     }
 
-    /// Polls the state of the stream.
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if a waiting [`Waker`] was awakened; `false` otherwise.
-    fn poll_state(&mut self) -> bool {
-        self.state.poll()
-    }
-
-    fn poll_read(
+    pub(crate) fn poll_connected(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let res = to_result_size! {
-            unsafe { spdk_sock_recv(self.sock, addr_of_mut!(*buf) as *mut _, buf.len()) }
-        };
-
-        match res {
-            Ok(s) => Poll::Ready(Ok(s)),
-            Err(EAGAIN) => {
-                if let StreamState::Connected(waker) = &mut self.state {
-                    *waker = Some(cx.waker().clone());
-                    return Poll::Pending;
-                }
-
-                unreachable!("poll_read called in unexpected state: {:?}", self.state);
-            }
-            Err(e) => Poll::Ready(Err(e.into())),
-        }
-    }
-
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let iov = IoSlice::new(buf);
-        let res = to_result_size! {
-            unsafe { spdk_sock_writev(self.sock, addr_of!(iov) as *mut IoVec, 1) }
-        };
-
-        match res {
-            Ok(s) => Poll::Ready(Ok(s)),
-            Err(EAGAIN) => {
-                if let StreamState::Connected(waker) = &mut self.state {
-                    *waker = Some(cx.waker().clone());
-                    return Poll::Pending;
-                }
-
-                unreachable!("poll_write called in unexpected state: {:?}", self.state);
-            }
-            Err(e) => Poll::Ready(Err(e.into())),
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let res = to_result! {
-            unsafe { spdk_sock_close(&mut self.sock as *mut _) }
-        };
+    ) -> Poll<Result<(), Errno>> {
+        let res = to_result!(unsafe { spdk_sock_flush(self.sock) });
 
         match res {
             Ok(()) => Poll::Ready(Ok(())),
-            Err(e) => Poll::Ready(Err(e.into())),
+            Err(EAGAIN) => {
+                self.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
         }
+    }
+
+    pub(crate) fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, Errno>> {
+        let res = to_result_size!(unsafe {
+            spdk_sock_recv(self.sock, addr_of_mut!(*buf) as *mut _, buf.len())
+        });
+
+        match res {
+            Ok(bytes_read) => Poll::Ready(Ok(bytes_read)),
+            Err(EAGAIN) => {
+                self.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    pub(crate) fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Errno>> {
+        let iov = IoSlice::new(buf);
+        let res =
+            to_result_size!(unsafe { spdk_sock_writev(self.sock, addr_of!(iov) as *mut IoVec, 1) });
+
+        match res {
+            Ok(bytes_written) => Poll::Ready(Ok(bytes_written)),
+            Err(EAGAIN) => {
+                self.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+
+    pub(crate) fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Errno>> {
+        Poll::Ready(Ok(()))
+    }
+
+    pub(crate) fn poll_close(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Errno>> {
+        Poll::Ready(to_result!(unsafe {
+            spdk_sock_close(&mut self.sock as *mut _)
+        }))
     }
 }
 
-impl Drop for TcpStreamInner {
+impl AsRawSock for TcpStreamSocket {
+    fn as_raw_sock(&self) -> *mut spdk_sock {
+        self.sock
+    }
+}
+
+impl Polled for TcpStreamSocket {
+    fn poll(mut self: Pin<&mut Self>) -> bool {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+            return true;
+        }
+
+        false
+    }
+}
+
+impl Drop for TcpStreamSocket {
     fn drop(&mut self) {
         let res = to_result! {
             unsafe { spdk_sock_close(&mut self.sock as *mut _) }
@@ -254,9 +195,70 @@ impl Drop for TcpStreamInner {
     }
 }
 
-impl Polled for TcpStreamInner {
-    fn poll(mut self: Pin<&mut Self>) -> bool {
-        self.poll_state()
+#[derive(Debug)]
+pub(crate) struct RawTcpStreamVtable {
+    pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
+    pub(crate) poll_connected: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) poll_read:
+        unsafe fn(*const (), &mut Context<'_>, &mut [u8]) -> Poll<Result<usize, Errno>>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) poll_write:
+        unsafe fn(*const (), &mut Context<'_>, &[u8]) -> Poll<Result<usize, Errno>>,
+    pub(crate) poll_flush: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    pub(crate) poll_close: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    pub(crate) drop: unsafe fn(*const ()),
+}
+
+#[derive(Debug)]
+pub(crate) struct RawTcpStream {
+    data: *const (),
+    vtable: &'static RawTcpStreamVtable,
+}
+
+impl RawTcpStream {
+    pub(crate) fn new(data: *const (), vtable: &'static RawTcpStreamVtable) -> Self {
+        Self { data, vtable }
+    }
+
+    fn poll_connected(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+        unsafe { (self.vtable.poll_connected)(self.data, cx) }
+    }
+
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, Errno>> {
+        unsafe { (self.vtable.poll_read)(self.data, cx, buf) }
+    }
+
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Errno>> {
+        unsafe { (self.vtable.poll_write)(self.data, cx, buf) }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+        unsafe { (self.vtable.poll_flush)(self.data, cx) }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+        unsafe { (self.vtable.poll_close)(self.data, cx) }
+    }
+}
+
+impl AsRawSock for RawTcpStream {
+    fn as_raw_sock(&self) -> *mut spdk_sock {
+        unsafe { (self.vtable.as_raw_sock)(self.data) }
+    }
+}
+
+impl Drop for RawTcpStream {
+    fn drop(&mut self) {
+        unsafe { (self.vtable.drop)(self.data) }
     }
 }
 
@@ -269,29 +271,9 @@ impl Polled for TcpStreamInner {
 /// [`TcpListener::accept`]: crate::net::TcpListener::accept
 /// [`TcpListener::incoming`]: crate::net::TcpListener::incoming
 #[derive(Debug)]
-pub struct TcpStream(Poller<TcpStreamInner>);
+pub struct TcpStream(RawTcpStream);
 
 impl TcpStream {
-    /// Returns an immutable reference to the internal state of the stream.
-    #[inline]
-    fn inner(&self) -> &TcpStreamInner {
-        self.0.polled()
-    }
-
-    /// Returns an mutable reference to the internal state of the stream.
-    #[inline]
-    fn inner_mut(&mut self) -> &mut TcpStreamInner {
-        self.0.polled_mut()
-    }
-
-    /// Attempts to connect a stream to the specified socket address.
-    async fn connect_one(addr: SocketAddr, opts: &spdk_sock_opts) -> Result<Self, Errno> {
-        Connector(Some(TcpStream(Poller::new_in_place(|inner| {
-            TcpStreamInner::connect_in_place(inner, addr, opts)
-        }))))
-        .await
-    }
-
     /// Creates a TCP connection to the specified socket address.
     ///
     /// If `addr` yields multiple socket addresses, `connect` will attempt to connect to each until
@@ -310,7 +292,7 @@ impl TcpStream {
         let mut last_err = EINVAL;
 
         for addr in addrs.to_socket_addr().await? {
-            match Self::connect_one(addr, &opts).await {
+            match Connector(Some(connect_polled_stream(addr, &opts))).await {
                 Ok(stream) => return Ok(stream),
                 Err(e) => last_err = e,
             }
@@ -332,7 +314,7 @@ impl AsyncRead for TcpStream {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(self.inner_mut()).poll_read(cx, buf)
+        Pin::new(&mut self.0).poll_read(cx, buf).map_err(Into::into)
     }
 }
 
@@ -342,21 +324,23 @@ impl AsyncWrite for TcpStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(self.inner_mut()).poll_write(cx, buf)
+        Pin::new(&mut self.0)
+            .poll_write(cx, buf)
+            .map_err(Into::into)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(self.inner_mut()).poll_flush(cx)
+        Pin::new(&mut self.0).poll_flush(cx).map_err(Into::into)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(self.inner_mut()).poll_close(cx)
+        Pin::new(&mut self.0).poll_close(cx).map_err(Into::into)
     }
 }
 
 impl AsRawSock for TcpStream {
     fn as_raw_sock(&self) -> *mut spdk_sock {
-        self.inner().sock
+        self.0.as_raw_sock()
     }
 }
 
@@ -370,9 +354,6 @@ impl From<Accepted> for TcpStream {
 
         assert!(!value.0.is_null());
 
-        Self(Poller::new(TcpStreamInner {
-            sock: value.0,
-            state: StreamState::Connected(None),
-        }))
+        Self(new_polled_stream(value.0))
     }
 }

--- a/spdk/src/task/poller.rs
+++ b/spdk/src/task/poller.rs
@@ -154,13 +154,22 @@ where
         Self(inner)
     }
 
-    pub(crate) fn into_raw(p: Self) -> *mut Self {
+    /// Consumes an `Poller<T>` instance and returns the wrapped pointer.
+    ///
+    /// To avoid a memory leak, the pointer must be converted back to a
+    /// `Poller<T>` using the [`Poller::from_raw()`] function.
+    pub fn into_raw(p: Self) -> *mut Self {
         let mut p = ManuallyDrop::new(p);
 
         (&mut *p.0) as *mut _ as *mut Self
     }
 
-    pub(crate) unsafe fn from_raw(p: *const Self) -> Self {
+    /// Constructs a `Poller<T>` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the raw pointer is non-null and valid.
+    pub unsafe fn from_raw(p: *const Self) -> Self {
         unsafe { transmute(Box::from_raw(p as *mut PollerInner<T>)) }
     }
 

--- a/spdk/src/task/poller.rs
+++ b/spdk/src/task/poller.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::c_void,
     fmt::{self, Debug},
     future::Future,
-    mem::{MaybeUninit, transmute},
+    mem::{ManuallyDrop, MaybeUninit, transmute},
     pin::Pin,
     ptr::null_mut,
     task::{Context, Poll},
@@ -152,6 +152,16 @@ where
         assert!(!inner.poller.is_null());
 
         Self(inner)
+    }
+
+    pub(crate) fn into_raw(p: Self) -> *mut Self {
+        let mut p = ManuallyDrop::new(p);
+
+        (&mut *p.0) as *mut _ as *mut Self
+    }
+
+    pub(crate) unsafe fn from_raw(p: *const Self) -> Self {
+        unsafe { transmute(Box::from_raw(p as *mut PollerInner<T>)) }
     }
 
     /// Returns a reference to the polled type.


### PR DESCRIPTION
Socket groups provide a more efficient mechanism for polling multiple TCP sockets vs. creating separate pollers for each.