### PR TITLE
chore: adds `spdk::Result<T>` type alias

### DIFF
--- a/spdk-macros/src/lib.rs
+++ b/spdk-macros/src/lib.rs
@@ -258,7 +258,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// impl NullRs {
 ///     /// Creates a new NullRs block device.
-///     pub fn try_new() -> Result<Device<Owned>, Errno> {
+///     pub fn try_new() -> spdk::Result<Device<Owned>> {
 ///         let mut null = NullRsModule::new_bdev(c"null-rs", NullRs::default());
 ///
 ///         null.bdev.blocklen = 4096;
@@ -273,7 +273,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// impl BDevOps for NullRs {
 ///     type IoChannel = NullRsChannel;
 ///
-///     async fn destruct(&mut self) -> Result<(), Errno> {
+///     async fn destruct(&mut self) -> spdk::Result<()> {
 ///         Ok(())
 ///     }
 ///

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -12,7 +12,7 @@ use spdk::{
     bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps},
     block::{Device, IoType, Owned},
     dma,
-    errors::{ENOTSUP, Errno},
+    errors::ENOTSUP,
     runtime::reactors,
     task::{self},
     thread::Thread,
@@ -55,7 +55,7 @@ struct EchoChannel {
 impl EchoChannel {
     // The `reader `condition variable releases the lock during the await.
     #[allow(clippy::await_holding_lock)]
-    async fn do_read(&self, io: &mut BDevIo<()>) -> Result<(), Errno> {
+    async fn do_read(&self, io: &mut BDevIo<()>) -> spdk::Result<()> {
         let offset_blocks = io.offset_blocks();
         let dst_buf = io.buffers_mut();
 
@@ -84,7 +84,7 @@ impl EchoChannel {
 
     // The `writer `condition variable releases the lock during the await.
     #[allow(clippy::await_holding_lock)]
-    async fn do_write(&self, io: &mut BDevIo<()>) -> Result<(), Errno> {
+    async fn do_write(&self, io: &mut BDevIo<()>) -> spdk::Result<()> {
         let mut src_buf = self.device.src_buf.lock();
 
         while src_buf.is_some() {
@@ -107,7 +107,7 @@ impl EchoChannel {
 impl BDevIoChannelOps for EchoChannel {
     type IoContext = ();
 
-    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> spdk::Result<()> {
         match io.io_type() {
             IoType::Read => self.do_read(io).await,
             IoType::Write => self.do_write(io).await,
@@ -122,7 +122,7 @@ struct Echo {
 }
 
 impl Echo {
-    fn try_new(name: &CStr) -> Result<Device<Owned>, Errno> {
+    fn try_new(name: &CStr) -> spdk::Result<Device<Owned>> {
         let mut echo = EchoModule::new_bdev(name, Self::default());
 
         echo.bdev.blocklen = 4096;
@@ -148,7 +148,7 @@ unsafe impl Sync for Echo {}
 impl BDevOps for Echo {
     type IoChannel = EchoChannel;
 
-    async fn destruct(&mut self) -> Result<(), Errno> {
+    async fn destruct(&mut self) -> spdk::Result<()> {
         Ok(())
     }
 
@@ -156,7 +156,7 @@ impl BDevOps for Echo {
         matches!(io_type, IoType::Read | IoType::Write)
     }
 
-    fn new_io_channel(&mut self) -> Result<EchoChannel, Errno> {
+    fn new_io_channel(&mut self) -> spdk::Result<EchoChannel> {
         let device = self.inner.clone();
 
         Ok(EchoChannel { device })

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -4,7 +4,6 @@ use spdk::{
     bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps},
     block::{Device, IoType, Owned},
     dma,
-    errors::Errno,
 };
 
 /// Implements the NullRs block device module.
@@ -23,7 +22,7 @@ struct NullRsChannel;
 impl BDevIoChannelOps for NullRsChannel {
     type IoContext = ();
 
-    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> spdk::Result<()> {
         if io.io_type() == IoType::Read {
             let dst = io.buffers_mut();
 
@@ -43,7 +42,7 @@ unsafe impl Sync for NullRs {}
 
 impl NullRs {
     /// Creates a new NullRs block device.
-    pub fn try_new() -> Result<Device<Owned>, Errno> {
+    pub fn try_new() -> spdk::Result<Device<Owned>> {
         let mut null = NullRsModule::new_bdev(c"null-rs", NullRs);
 
         null.bdev.blocklen = 4096;
@@ -58,7 +57,7 @@ impl NullRs {
 impl BDevOps for NullRs {
     type IoChannel = NullRsChannel;
 
-    async fn destruct(&mut self) -> Result<(), Errno> {
+    async fn destruct(&mut self) -> spdk::Result<()> {
         Ok(())
     }
 
@@ -66,7 +65,7 @@ impl BDevOps for NullRs {
         matches!(io_type, IoType::Read | IoType::Write)
     }
 
-    fn new_io_channel(&mut self) -> Result<NullRsChannel, Errno> {
+    fn new_io_channel(&mut self) -> spdk::Result<NullRsChannel> {
         Ok(NullRsChannel)
     }
 }

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -8,7 +8,7 @@ use spdk::{
     bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps, malloc},
     block::{Any, Descriptor, Device, IoChannel, IoType, Owned},
     dma::{self},
-    errors::{ENOTSUP, Errno},
+    errors::ENOTSUP,
     thread,
 };
 
@@ -27,7 +27,7 @@ struct PassthruRsChannel {
 impl BDevIoChannelOps for PassthruRsChannel {
     type IoContext = ();
 
-    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> Result<(), Errno> {
+    async fn submit_request(&mut self, io: &mut BDevIo<Self::IoContext>) -> spdk::Result<()> {
         match io.io_type() {
             IoType::Read => {
                 let num_blocks = io.num_blocks();
@@ -81,7 +81,7 @@ unsafe impl Sync for PassthruRs {}
 impl BDevOps for PassthruRs {
     type IoChannel = PassthruRsChannel;
 
-    async fn destruct(&mut self) -> Result<(), Errno> {
+    async fn destruct(&mut self) -> spdk::Result<()> {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl BDevOps for PassthruRs {
         self.base.io_type_supported(io_type)
     }
 
-    fn new_io_channel(&mut self) -> Result<PassthruRsChannel, Errno> {
+    fn new_io_channel(&mut self) -> spdk::Result<PassthruRsChannel> {
         let ch = self.desc.io_channel()?;
 
         Ok(PassthruRsChannel { ch })
@@ -97,7 +97,7 @@ impl BDevOps for PassthruRs {
 }
 
 impl PassthruRs {
-    pub fn try_new(base: Device<Any>, desc: Descriptor) -> Result<Device<Owned>, Errno> {
+    pub fn try_new(base: Device<Any>, desc: Descriptor) -> spdk::Result<Device<Owned>> {
         let name = CString::new(format!("passthru-rs-{}", base.name().to_string_lossy())).unwrap();
         let mut passthru = PassthruRsModule::new_bdev(name.as_c_str(), PassthruRs { base, desc });
 

--- a/spdk/examples/net_group.rs
+++ b/spdk/examples/net_group.rs
@@ -5,7 +5,6 @@ use futures::{AsyncReadExt, AsyncWriteExt};
 use spdk::{
     self,
     cli::Parser,
-    errors::Errno,
     net::{Accepted, SocketGroup, TcpSocketExt, TcpSocketRemote, TcpStream},
     task::JoinHandle,
     thread::{self, Thread},
@@ -23,7 +22,7 @@ struct Args {
 
 const HELLO_WORLD: &str = "Hello, World!";
 
-async fn handle_client(client: Accepted) -> Result<(), Errno> {
+async fn handle_client(client: Accepted) -> spdk::Result<()> {
     let name = CString::new(format!(
         "client {}",
         client.peer_addr().expect("client connected")
@@ -49,7 +48,7 @@ async fn handle_client(client: Accepted) -> Result<(), Errno> {
         .await
 }
 
-fn run_server(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
+fn run_server(args: &'static Args) -> JoinHandle<spdk::Result<()>> {
     thread::spawn_local(async move {
         let group = SocketGroup::new();
         let mut listener = group.bind(args.host.as_str()).await?;
@@ -65,7 +64,7 @@ fn run_server(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
     })
 }
 
-fn run_client(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
+fn run_client(args: &'static Args) -> JoinHandle<spdk::Result<()>> {
     thread::spawn_local(async move {
         println!("CLIENT: Connecting to {}", args.host);
 

--- a/spdk/examples/net_hello_world.rs
+++ b/spdk/examples/net_hello_world.rs
@@ -5,7 +5,6 @@ use futures::{AsyncReadExt, AsyncWriteExt};
 use spdk::{
     self,
     cli::Parser,
-    errors::Errno,
     net::{Accepted, TcpListener, TcpSocketExt, TcpSocketRemote, TcpStream},
     task::JoinHandle,
     thread::{self, Thread},
@@ -23,7 +22,7 @@ struct Args {
 
 const HELLO_WORLD: &str = "Hello, World!";
 
-async fn handle_client(client: Accepted) -> Result<(), Errno> {
+async fn handle_client(client: Accepted) -> spdk::Result<()> {
     let name = CString::new(format!(
         "client {}",
         client.peer_addr().expect("client connected")
@@ -48,7 +47,7 @@ async fn handle_client(client: Accepted) -> Result<(), Errno> {
         .await
 }
 
-fn run_server(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
+fn run_server(args: &'static Args) -> JoinHandle<spdk::Result<()>> {
     thread::spawn_local(async move {
         let mut listener = TcpListener::bind(args.host.as_str()).await?;
 
@@ -63,7 +62,7 @@ fn run_server(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
     })
 }
 
-fn run_client(args: &'static Args) -> JoinHandle<Result<(), Errno>> {
+fn run_client(args: &'static Args) -> JoinHandle<spdk::Result<()>> {
     thread::spawn_local(async move {
         println!("CLIENT: Connecting to {}", args.host);
 

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -25,6 +25,7 @@ use spdk_sys::{
 use ternary_rs::if_else;
 
 use crate::{
+    Result,
     block::{Any, Device, IoType, Owned, OwnedOps},
     errors::{ECANCELED, EINPROGRESS, EINVAL, ENOMEM, Errno},
     task::{Promise, Promissory},
@@ -80,8 +81,8 @@ impl From<Errno> for IoStatus {
     }
 }
 
-impl From<Result<(), Errno>> for IoStatus {
-    fn from(result: Result<(), Errno>) -> Self {
+impl From<Result<()>> for IoStatus {
+    fn from(result: Result<()>) -> Self {
         match result {
             Ok(_) => IoStatus::Success,
             Err(e) => e.into(),
@@ -119,7 +120,7 @@ pub trait BDevIoChannelOps: 'static {
     fn submit_request(
         &mut self,
         io: &mut BDevIo<Self::IoContext>,
-    ) -> impl Future<Output = Result<(), Errno>>;
+    ) -> impl Future<Output = Result<()>>;
 }
 
 /// A BDev I/O channel implementation.
@@ -176,7 +177,7 @@ where
 {
     type Error = Errno;
 
-    fn try_from(channel: *mut spdk_io_channel) -> Result<Self, Self::Error> {
+    fn try_from(channel: *mut spdk_io_channel) -> Result<Self> {
         match NonNull::new(channel) {
             Some(channel) => Ok(Self {
                 channel,
@@ -361,7 +362,7 @@ where
     ///
     /// Any buffers allocated by this method will automatically be freed on
     /// completion of this I/O request.
-    pub async fn allocate_buffers<'a>(&'a mut self, length: u64) -> Result<(), Errno> {
+    pub async fn allocate_buffers<'a>(&'a mut self, length: u64) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(move |p| {
                 self.internal_ctx_mut()
@@ -412,7 +413,7 @@ pub trait BDevOps: Send + Sync + 'static {
     type IoChannel: BDevIoChannelOps;
 
     /// Destroys the BDev.
-    fn destruct(&mut self) -> impl Future<Output = Result<(), Errno>>;
+    fn destruct(&mut self) -> impl Future<Output = Result<()>>;
 
     /// Returns whether the specified I/O type is supported by the BDev.
     fn io_type_supported(&self, io_type: IoType) -> bool;
@@ -424,12 +425,12 @@ pub trait BDevOps: Send + Sync + 'static {
     /// The default implementation returns a per-thread I/O channel for the
     /// BDev. Implementations may override this method to provide different
     /// behavior.
-    fn get_io_channel(&self) -> Result<BDevIoChannel<Self::IoChannel>, Errno> {
+    fn get_io_channel(&self) -> Result<BDevIoChannel<Self::IoChannel>> {
         unsafe { spdk_get_io_channel(self as *const _ as *mut _).try_into() }
     }
 
     /// Creates a new I/O channel for the BDev.
-    fn new_io_channel(&mut self) -> Result<Self::IoChannel, Errno>;
+    fn new_io_channel(&mut self) -> Result<Self::IoChannel>;
 
     /// Returns the size in bytes of the per-I/O context.
     fn get_io_context_size() -> usize {
@@ -487,7 +488,7 @@ where
 
     /// Registers the BDev with the SPDK subsystem. This function must be called
     /// from the SPDK application thread.
-    pub fn register(&mut self) -> Result<(), Errno> {
+    pub fn register(&mut self) -> Result<()> {
         unsafe {
             spdk_io_device_register(
                 self.bdev.ctxt,
@@ -508,7 +509,7 @@ where
 
     /// Unregisters the BDev from the SPDK subsystem. This function must be
     /// called from the SPDK application thread.
-    pub async fn unregister(self: Box<Self>) -> Result<(), Errno> {
+    pub async fn unregister(self: Box<Self>) -> Result<()> {
         let bdev_ptr = self.into_bdev_ptr();
 
         Promise::new()
@@ -679,7 +680,7 @@ impl<T: BDevOps> OwnedOps for OwnedImpl<T> {
         addr_of!(self.0.bdev) as *mut _
     }
 
-    async fn destroy(self) -> Result<(), Errno> {
+    async fn destroy(self) -> Result<()> {
         // The BDev implementation's `destruct` method is invoked by the called
         // to unregister the device and will take care of dropping the box. We
         // avoid dropping the box here to prevent double-free.

--- a/spdk/src/bdev/malloc.rs
+++ b/spdk/src/bdev/malloc.rs
@@ -14,8 +14,8 @@ use spdk_sys::{
 };
 
 use crate::{
+    Result,
     block::{Device, Owned, OwnedOps},
-    errors::Errno,
     task::{Promise, Promissory},
     to_result,
 };
@@ -67,7 +67,7 @@ impl Builder {
     ///
     /// [`Device<Malloc>::destroy`]: method@crate::block::Device<Malloc>::destroy
     /// [`task::yield_now`]: function@crate::task::yield_now
-    pub fn build(self) -> Result<Device<Malloc>, Errno> {
+    pub fn build(self) -> Result<Device<Malloc>> {
         let mut malloc = null_mut();
 
         unsafe { to_result!(create_malloc_disk(&mut malloc, &self.0))? };
@@ -94,7 +94,7 @@ impl OwnedOps for Malloc {
         self.0.as_ptr()
     }
 
-    async fn destroy(self) -> Result<(), Errno> {
+    async fn destroy(self) -> Result<()> {
         Promise::new()
             .request(move |p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_status(p);

--- a/spdk/src/block/any.rs
+++ b/spdk/src/block/any.rs
@@ -1,6 +1,6 @@
 use spdk_sys::spdk_bdev;
 
-use crate::errors::{EPERM, Errno};
+use crate::{Result, errors::EPERM};
 
 use super::{Owned, OwnedOps};
 
@@ -12,7 +12,7 @@ impl OwnedOps for Any {
         unreachable!("Any::as_ptr() should never be called")
     }
 
-    async fn destroy(self) -> Result<(), Errno> {
+    async fn destroy(self) -> Result<()> {
         Err(EPERM)
     }
 }

--- a/spdk/src/block/descriptor.rs
+++ b/spdk/src/block/descriptor.rs
@@ -9,6 +9,7 @@ use spdk_sys::{
 use ternary_rs::if_else;
 
 use crate::{
+    Result,
     block::Any,
     errors::{EINVAL, ENOMEM, Errno},
     task::{Promise, Promissory},
@@ -39,7 +40,7 @@ impl Descriptor {
     }
 
     /// Open a block device by its name.
-    pub async fn open(name: &CStr, write: bool) -> Result<Descriptor, Errno> {
+    pub async fn open(name: &CStr, write: bool) -> Result<Descriptor> {
         Promise::new()
             .request(|p| {
                 let (cb_fn, cb_arg) = (Self::open_complete, Promissory::into_raw(p.clone()));
@@ -78,7 +79,7 @@ impl Descriptor {
     ///
     /// I/O channels are bound to the `spdk_thread` on which this function is
     /// called. The returned [`IoChannel`] cannot be used from any other thread.
-    pub fn io_channel(&self) -> Result<IoChannel, Errno> {
+    pub fn io_channel(&self) -> Result<IoChannel> {
         IoChannel::new(self)
     }
 }
@@ -92,7 +93,7 @@ impl Drop for Descriptor {
 impl TryFrom<*mut spdk_bdev_desc> for Descriptor {
     type Error = Errno;
 
-    fn try_from(desc: *mut spdk_bdev_desc) -> Result<Self, Self::Error> {
+    fn try_from(desc: *mut spdk_bdev_desc) -> Result<Self> {
         match NonNull::new(desc as *mut _) {
             Some(ptr) => Ok(Self(ptr)),
             None => Err(ENOMEM),

--- a/spdk/src/block/device.rs
+++ b/spdk/src/block/device.rs
@@ -22,8 +22,9 @@ use spdk_sys::{
 };
 
 use crate::{
+    Result,
     block::{Any, Owned, OwnedOps},
-    errors::{ENODEV, EPERM, Errno},
+    errors::{ENODEV, EPERM},
     thread,
 };
 
@@ -229,7 +230,7 @@ impl<T: OwnedOps> Device<T> {
     /// Only an owned device can be destroyed. This function returns `Err(EPERM)`
     /// if called on a borrowed device and `Err(ENODEV)` if called on a device
     /// that neither owns nor borrows the underlying `spdk_bdev` pointer.
-    pub async fn destroy(mut self) -> Result<(), Errno> {
+    pub async fn destroy(mut self) -> Result<()> {
         match self.0 {
             OwnershipState::Borrowed(_) => Err(EPERM),
             OwnershipState::None => Err(ENODEV),
@@ -241,7 +242,7 @@ impl<T: OwnedOps> Device<T> {
     }
 
     /// Opens the device asynchronously.
-    pub async fn open(&self, write: bool) -> Result<Descriptor, Errno> {
+    pub async fn open(&self, write: bool) -> Result<Descriptor> {
         Descriptor::open(self.name(), write).await
     }
 
@@ -293,13 +294,13 @@ impl<T: OwnedOps> Device<T> {
     }
 
     /// Get the [`Layout`] for a buffer of the specified byte size.
-    pub fn layout_for_size(&self, size: usize) -> Result<Layout, LayoutError> {
+    pub fn layout_for_size(&self, size: usize) -> std::result::Result<Layout, LayoutError> {
         Layout::from_size_align(size, self.buffer_alignment())
     }
 
     /// Get the [`Layout`] for a buffer of the specified number of logical
     /// blocks.
-    pub fn layout_for_blocks(&self, count: u64) -> Result<Layout, LayoutError> {
+    pub fn layout_for_blocks(&self, count: u64) -> std::result::Result<Layout, LayoutError> {
         self.layout_for_size(count as usize * self.logical_block_size() as usize)
     }
 

--- a/spdk/src/block/io_channel.rs
+++ b/spdk/src/block/io_channel.rs
@@ -22,7 +22,8 @@ use spdk_sys::{
 use ternary_rs::if_else;
 
 use crate::{
-    errors::{EINVAL, EIO, ENOMEM, Errno},
+    Result,
+    errors::{EINVAL, EIO, ENOMEM},
     task::{Promise, Promissory},
     thread::Thread,
     to_poll_pending_on_ok,
@@ -63,7 +64,7 @@ pub struct IoChannel {
 
 impl IoChannel {
     /// Creates a new [`IoChannel`].
-    pub(crate) fn new(desc: &Descriptor) -> Result<Self, Errno> {
+    pub(crate) fn new(desc: &Descriptor) -> Result<Self> {
         // SAFETY: `desc` is guaranteed to contain a non-null pointer. The SPDK
         // also guarantees the descriptor will live as long as there are
         // outstanding I/O channels.
@@ -127,7 +128,7 @@ impl IoChannel {
     ///
     /// This function returns `Err(EINVAL)` if the I/O channel an I/O buffer is
     /// available on the current thread..
-    async fn wait_io_available(&mut self) -> Result<(), Errno> {
+    async fn wait_io_available(&mut self) -> Result<()> {
         let ch = self.channel;
 
         Promise::with_context_cyclic(|w| IoWait::new(w, self))
@@ -160,9 +161,9 @@ impl IoChannel {
 
     /// Executes an I/O operation, queuing the I/O for later execution if there
     /// are no `spdk_bdev_io` structures available.
-    async fn execute_io<F, T>(&mut self, data: PhantomData<T>, mut start_fn: F) -> Result<(), Errno>
+    async fn execute_io<F, T>(&mut self, data: PhantomData<T>, mut start_fn: F) -> Result<()>
     where
-        F: FnMut(&mut Self, &mut Rc<Promissory<(), PhantomData<T>>>) -> Poll<Result<(), Errno>>,
+        F: FnMut(&mut Self, &mut Rc<Promissory<(), PhantomData<T>>>) -> Poll<Result<()>>,
         T: Unpin,
     {
         loop {
@@ -178,7 +179,7 @@ impl IoChannel {
     }
 
     /// Resets the block device zone.
-    pub async fn reset_zone<'a>(&'a mut self, zone_id: u64) -> Result<(), Errno> {
+    pub async fn reset_zone<'a>(&'a mut self, zone_id: u64) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -203,11 +204,7 @@ impl IoChannel {
 
     /// Writes the data in the buffer to the block device at the specified
     /// byte offset.
-    pub async fn write_at<'a, B: AsRef<[u8]>>(
-        &'a mut self,
-        buf: &'a B,
-        offset: u64,
-    ) -> Result<(), Errno> {
+    pub async fn write_at<'a, B: AsRef<[u8]>>(&'a mut self, buf: &'a B, offset: u64) -> Result<()> {
         self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let buf = buf.as_ref();
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
@@ -239,7 +236,7 @@ impl IoChannel {
         bufs: &'a B,
         offset: u64,
         length: u64,
-    ) -> Result<(), Errno>
+    ) -> Result<()>
     where
         B: AsRef<[IoSlice<'a>]> + ?Sized,
     {
@@ -276,7 +273,7 @@ impl IoChannel {
         &'a mut self,
         buf: &'a B,
         offset_blocks: u64,
-    ) -> Result<(), Errno> {
+    ) -> Result<()> {
         self.execute_io(PhantomData::<(&'a mut Self, &'a B)>, |this, p| {
             let buf = buf.as_ref();
             let logical_block_size = this.device().logical_block_size() as usize;
@@ -314,7 +311,7 @@ impl IoChannel {
         bufs: &'a B,
         offset_blocks: u64,
         num_blocks: u64,
-    ) -> Result<(), Errno>
+    ) -> Result<()>
     where
         B: AsRef<[IoSlice<'a>]> + ?Sized,
     {
@@ -344,7 +341,7 @@ impl IoChannel {
     }
 
     /// Writes zeroes to the block device at the specified byte offset.
-    pub async fn write_zeroes_at<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+    pub async fn write_zeroes_at<'a>(&'a mut self, offset: u64, len: u64) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -372,7 +369,7 @@ impl IoChannel {
         &'a mut self,
         offset_blocks: u64,
         num_blocks: u64,
-    ) -> Result<(), Errno> {
+    ) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -401,7 +398,7 @@ impl IoChannel {
         &'a mut self,
         buf: &'a mut B,
         offset: u64,
-    ) -> Result<(), Errno> {
+    ) -> Result<()> {
         self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -432,7 +429,7 @@ impl IoChannel {
         bufs: &'a mut B,
         offset: u64,
         length: u64,
-    ) -> Result<(), Errno>
+    ) -> Result<()>
     where
         B: AsMut<[IoSliceMut<'a>]> + ?Sized,
     {
@@ -469,7 +466,7 @@ impl IoChannel {
         &'a mut self,
         buf: &'a mut B,
         offset_blocks: u64,
-    ) -> Result<(), Errno> {
+    ) -> Result<()> {
         self.execute_io(PhantomData::<(&'a mut Self, &'a mut B)>, |this, p| {
             let buf = buf.as_mut();
             let logical_block_size = this.device().logical_block_size() as usize;
@@ -507,7 +504,7 @@ impl IoChannel {
         bufs: &'a mut B,
         offset_blocks: u64,
         num_blocks: u64,
-    ) -> Result<(), Errno>
+    ) -> Result<()>
     where
         B: AsMut<[IoSliceMut<'a>]> + ?Sized,
     {
@@ -542,7 +539,7 @@ impl IoChannel {
         src_offset_blocks: u64,
         dst_offset_blocks: u64,
         num_blocks: u64,
-    ) -> Result<(), Errno> {
+    ) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -568,7 +565,7 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of bytes is no longer
     /// valid.
-    pub async fn unmap<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+    pub async fn unmap<'a>(&'a mut self, offset: u64, len: u64) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -593,11 +590,7 @@ impl IoChannel {
 
     /// Notifies the block device that the specified range of blocks is no longer
     /// valid.
-    pub async fn unmap_blocks<'a>(
-        &'a mut self,
-        offset_blocks: u64,
-        num_blocks: u64,
-    ) -> Result<(), Errno> {
+    pub async fn unmap_blocks<'a>(&'a mut self, offset_blocks: u64, num_blocks: u64) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -625,7 +618,7 @@ impl IoChannel {
     ///
     /// For devices with volatile cache, data is not guaranteed to be persistent
     /// until the completion of the flush operation.
-    pub async fn flush<'a>(&'a mut self, offset: u64, len: u64) -> Result<(), Errno> {
+    pub async fn flush<'a>(&'a mut self, offset: u64, len: u64) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 
@@ -649,7 +642,7 @@ impl IoChannel {
     }
 
     /// Resets the block device.
-    pub async fn reset<'a>(&'a mut self) -> Result<(), Errno> {
+    pub async fn reset<'a>(&'a mut self) -> Result<()> {
         self.execute_io(PhantomData::<&'a mut Self>, |this, p| {
             let (cb_fn, cb_arg) = (Self::io_complete, Promissory::into_raw(p.clone()));
 

--- a/spdk/src/block/owned.rs
+++ b/spdk/src/block/owned.rs
@@ -1,9 +1,8 @@
-use std::{mem, pin::Pin, ptr::NonNull};
+use std::{future::Future, mem, pin::Pin, ptr::NonNull};
 
-use futures::Future;
 use spdk_sys::spdk_bdev;
 
-use crate::{block::Device, errors::Errno};
+use crate::{Result, block::Device};
 
 /// A trait for owned block devices.
 pub trait OwnedOps: From<Owned> + 'static {
@@ -11,13 +10,13 @@ pub trait OwnedOps: From<Owned> + 'static {
     fn as_ptr(&self) -> *mut spdk_bdev;
 
     /// Destroy the block device asynchronously.
-    fn destroy(self) -> impl std::future::Future<Output = Result<(), Errno>>;
+    fn destroy(self) -> impl Future<Output = Result<()>>;
 }
 
-type DestroyFn = fn(Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>>>>;
+type DestroyFn = fn(Owned) -> Pin<Box<dyn Future<Output = Result<()>>>>;
 
 /// Destroys the type-erased device managed by the specified [`Owned`] instance.
-fn destroy_device<T>(owned: Owned) -> Pin<Box<dyn Future<Output = Result<(), Errno>>>>
+fn destroy_device<T>(owned: Owned) -> Pin<Box<dyn Future<Output = Result<()>>>>
 where
     T: OwnedOps,
 {
@@ -67,7 +66,7 @@ impl OwnedOps for Owned {
         self.bdev.as_ptr()
     }
 
-    async fn destroy(self) -> Result<(), Errno> {
+    async fn destroy(self) -> Result<()> {
         (self.destroy_fn)(self).await
     }
 }

--- a/spdk/src/cli.rs
+++ b/spdk/src/cli.rs
@@ -1,5 +1,5 @@
 //! Command-line interface support for SPDK applications.
-use crate::{errors::Errno, runtime::Builder};
+use crate::{Result, runtime::Builder};
 
 pub use spdk_macros::Parser;
 
@@ -9,7 +9,7 @@ pub trait Parser {
     /// [`Runtime`].
     ///
     /// [`Runtime`]: ../runtime/struct.Runtime.html
-    fn parse() -> Result<Builder, Errno>;
+    fn parse() -> Result<Builder>;
 
     /// Returns a reference to the parsed command-line arguments.
     fn get() -> &'static Self;

--- a/spdk/src/dma.rs
+++ b/spdk/src/dma.rs
@@ -19,7 +19,7 @@ use spdk_sys::{
     iovec as IoVec, spdk_dma_free, spdk_dma_malloc, spdk_dma_realloc, spdk_dma_zmalloc,
 };
 
-use crate::errors::{EINVAL, Errno};
+use crate::{Result, errors::EINVAL};
 
 /// Allocates memory using the SPDK memory allocator.
 pub fn alloc(layout: Layout) -> *mut u8 {
@@ -147,7 +147,7 @@ impl Buffer {
     ///
     /// Returns [`EINVAL`] if the offset is greater than the
     /// size of the buffer.
-    pub fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<usize, Errno> {
+    pub fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<usize> {
         let size = self.size() as u64;
 
         if offset > size {
@@ -181,7 +181,7 @@ impl Buffer {
     ///
     /// Returns [`EINVAL`] if the offset is greater than the
     /// size of the buffer.
-    pub fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<usize, Errno> {
+    pub fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<usize> {
         let size = self.size() as u64;
 
         if offset > size {

--- a/spdk/src/lib.rs
+++ b/spdk/src/lib.rs
@@ -22,3 +22,6 @@ pub use spdk_macros::main;
 
 #[cfg(feature = "bdev-module")]
 pub use spdk_macros::module;
+
+/// A specialized `Result` type for SPDK operations.
+pub type Result<T> = std::result::Result<T, errors::Errno>;

--- a/spdk/src/net/addr.rs
+++ b/spdk/src/net/addr.rs
@@ -15,9 +15,9 @@ use std::{
 use lazy_regex::{regex_captures, regex_is_match};
 use libanl::{self, EAI_INPROGRESS, GAI_NOWAIT, eai_to_result, gai_error, gaicb, getaddrinfo_a};
 use libc::{AF_INET, AF_INET6, NI_NUMERICHOST, NI_NUMERICSERV, addrinfo, getnameinfo};
-use ternary_rs::if_else;
 
 use crate::{
+    Result,
     errors::{EINVAL, Errno},
     task::{Polled, Poller},
 };
@@ -178,7 +178,7 @@ impl Display for SocketAddr {
 impl FromStr for SocketAddr {
     type Err = Errno;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         Ok(std::net::SocketAddr::from_str(s)
             .map_err(|_| EINVAL)?
             .into())
@@ -200,7 +200,7 @@ impl From<std::net::SocketAddr> for SocketAddr {
 impl TryFrom<&str> for SocketAddr {
     type Error = Errno;
 
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
+    fn try_from(s: &str) -> Result<Self> {
         SocketAddr::from_str(s)
     }
 }
@@ -340,28 +340,36 @@ impl ResolverInner {
     ///
     /// # Returns
     ///
-    /// This method returns `Ok(())` if the lookup operation was started successfully. Otherwise, it
-    /// returns a `Err(`[`libanl::Error`]`)` result.
+    /// This method returns `Poll:Pending` if the lookup operation was started successfully.
+    /// Otherwise, it returns a `Poll::Ready(Err(`[`Errno`]`))` result.
     ///
     /// [`Idle`]: ResolverState::Idle
-    fn poll_start(self: Pin<&Self>) -> Result<(), libanl::Error> {
+    fn poll_start(self: Pin<&Self>) -> Poll<Result<SocketAddrIter>> {
         let list = [addr_of!(self.req)].as_ptr();
 
         eai_to_result!(unsafe { getaddrinfo_a(GAI_NOWAIT, list as *mut _, 1, ptr::null_mut()) })
+            .err()
+            .map_or(Poll::Pending, |e| Poll::Ready(Err(e.into())))
     }
 
     /// Called to poll the result of an asynchronous socket address lookup.
     ///
     /// # Returns
     ///
-    /// This method returns `Ok(Some(`[`SocketAddrIter`]`))` if the lookup operation completed
-    /// successfully, `Ok(None)` if the operation is still in progress and
-    /// `Err(`[`libanl::Error`]`)` on error.
-    fn poll_result(self: Pin<&Self>) -> Result<Option<SocketAddrIter>, libanl::Error> {
+    /// This method returns `Poll::Ready(Ok(`[`SocketAddrIter`]`)))` if the lookup operation
+    /// completed successfully, `Poll::Pending` if the operation is still in progress and
+    /// `Poll::Ready(Err(`[`Errno`]`))` on error.
+    fn poll_result(self: Pin<&Self>) -> Poll<Result<SocketAddrIter>> {
         eai_to_result!(unsafe { gai_error(&self.req as *const _) })
             .err()
-            .map(|e| if_else!(e == EAI_INPROGRESS, Ok(None), Err(e)))
-            .unwrap_or_else(|| Ok(Some(SocketAddrIter::new(self.req.ar_result))))
+            .map(|e| {
+                if e == EAI_INPROGRESS {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(Err(e.into()))
+                }
+            })
+            .unwrap_or_else(|| Poll::Ready(Ok(SocketAddrIter::new(self.req.ar_result))))
     }
 
     /// Whether the asynchronous socket address lookup is done.
@@ -385,30 +393,21 @@ impl Polled for ResolverInner {
 }
 
 impl Future for ResolverInner {
-    type Output = Result<SocketAddrIter, Errno>;
+    type Output = Result<SocketAddrIter>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let state = self.as_mut().state_mut().poll(cx);
 
         match state {
-            ResolverState::Idle => self
-                .as_ref()
-                .poll_start()
-                .err()
-                .map_or(Poll::Pending, |e| Poll::Ready(Err(e.into()))),
+            ResolverState::Idle => self.as_ref().poll_start(),
             ResolverState::Resolving(_) => Poll::Pending,
             ResolverState::Waking => match self.as_ref().poll_result() {
-                Ok(Some(res)) => {
+                Poll::Ready(res) => {
                     self.state_mut().set_complete();
 
-                    Poll::Ready(Ok(res))
+                    Poll::Ready(res)
                 }
-                Ok(None) => Poll::Pending,
-                Err(e) => {
-                    self.state_mut().set_complete();
-
-                    Poll::Ready(Err(e.into()))
-                }
+                Poll::Pending => Poll::Pending,
             },
             _ => panic!("poll called in unexpected state: {:?}", state),
         }
@@ -427,7 +426,7 @@ impl Resolver {
 }
 
 impl Future for Resolver {
-    type Output = Result<SocketAddrIter, Errno>;
+    type Output = Result<SocketAddrIter>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         unsafe { self.map_unchecked_mut(|s| &mut s.0) }.poll(cx)
@@ -444,7 +443,7 @@ impl Future for Resolver {
 /// let addr = resolve("localhost:8080").await?.next().unwrap();
 /// println!("resolved {:?}", addr);
 /// ```
-pub async fn resolve<A>(addr: A) -> Result<A::Iter, Errno>
+pub async fn resolve<A>(addr: A) -> Result<A::Iter>
 where
     A: ToSocketAddrs,
 {
@@ -467,13 +466,13 @@ pub trait ToSocketAddrs {
     type Iter: Iterator<Item = SocketAddr>;
 
     /// Converts or resolves this object into an iterator of [`SocketAddr`] objects.
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>>;
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>>;
 }
 
 impl ToSocketAddrs for SocketAddr {
     type Iter = option::IntoIter<SocketAddr>;
 
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>> {
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>> {
         ready(Ok(Some(self.clone()).into_iter()))
     }
 }
@@ -481,7 +480,7 @@ impl ToSocketAddrs for SocketAddr {
 impl ToSocketAddrs for SocketAddrV4 {
     type Iter = option::IntoIter<SocketAddr>;
 
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>> {
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>> {
         ready(Ok(Some(SocketAddr::V4(self.clone())).into_iter()))
     }
 }
@@ -489,7 +488,7 @@ impl ToSocketAddrs for SocketAddrV4 {
 impl ToSocketAddrs for SocketAddrV6 {
     type Iter = option::IntoIter<SocketAddr>;
 
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>> {
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>> {
         ready(Ok(Some(SocketAddr::V6(self.clone())).into_iter()))
     }
 }
@@ -497,7 +496,7 @@ impl ToSocketAddrs for SocketAddrV6 {
 impl ToSocketAddrs for (&str, Option<&str>) {
     type Iter = SocketAddrIter;
 
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>> {
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>> {
         Resolver::new(self.0, self.1)
     }
 }
@@ -505,7 +504,7 @@ impl ToSocketAddrs for (&str, Option<&str>) {
 impl ToSocketAddrs for (&str, &str) {
     type Iter = SocketAddrIter;
 
-    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter, Errno>> {
+    fn to_socket_addr(&self) -> impl Future<Output = Result<Self::Iter>> {
         Resolver::new(self.0, Some(self.1))
     }
 }
@@ -513,7 +512,7 @@ impl ToSocketAddrs for (&str, &str) {
 impl ToSocketAddrs for &str {
     type Iter = SocketAddrIter;
 
-    async fn to_socket_addr(&self) -> Result<Self::Iter, Errno> {
+    async fn to_socket_addr(&self) -> Result<Self::Iter> {
         if let Some((_, host, service)) = regex_captures!(r#"^\[?([^\]]+)\]?:(.+)$"#, self) {
             return Resolver::new(host, Some(service)).await;
         }
@@ -525,7 +524,7 @@ impl ToSocketAddrs for &str {
 impl ToSocketAddrs for String {
     type Iter = SocketAddrIter;
 
-    async fn to_socket_addr(&self) -> Result<Self::Iter, Errno> {
+    async fn to_socket_addr(&self) -> Result<Self::Iter> {
         self.as_str().to_socket_addr().await
     }
 }

--- a/spdk/src/net/group.rs
+++ b/spdk/src/net/group.rs
@@ -18,7 +18,8 @@ use spdk_sys::{
 };
 
 use crate::{
-    errors::{EINVAL, Errno},
+    Result,
+    errors::EINVAL,
     net::ToSocketAddrs,
     task::{Polled, Poller},
     thread::Thread,
@@ -130,7 +131,7 @@ fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
 /// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
 /// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a
 /// [`TcpStream`].
-fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpListenerSocket>) };
 
     Pin::new(&mut this.sock).poll_accept(cx)
@@ -175,7 +176,7 @@ fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
 ///
 /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
 /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
-fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_connected(cx)
@@ -192,11 +193,7 @@ fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(
 /// available and `Poll::Pending` if no data was available.
 ///
 /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
-fn stream_poll_read(
-    data: *const (),
-    cx: &mut Context<'_>,
-    buf: &mut [u8],
-) -> Poll<Result<usize, Errno>> {
+fn stream_poll_read(data: *const (), cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_read(cx, buf)
@@ -217,7 +214,7 @@ fn stream_poll_read_vectored(
     data: *const (),
     cx: &mut Context<'_>,
     bufs: &mut [std::io::IoSliceMut<'_>],
-) -> Poll<Result<usize, Errno>> {
+) -> Poll<Result<usize>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_read_vectored(cx, bufs)
@@ -238,7 +235,7 @@ fn stream_poll_write_vectored(
     data: *const (),
     cx: &mut Context<'_>,
     bufs: &[std::io::IoSlice<'_>],
-) -> Poll<Result<usize, Errno>> {
+) -> Poll<Result<usize>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_write_vectored(cx, bufs)
@@ -255,11 +252,7 @@ fn stream_poll_write_vectored(
 /// written and `Poll::Pending` data cannot currently be written.
 ///
 /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
-fn stream_poll_write(
-    data: *const (),
-    cx: &mut Context<'_>,
-    buf: &[u8],
-) -> Poll<Result<usize, Errno>> {
+fn stream_poll_write(data: *const (), cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     // A socket group does not provide notification of write buffer availability, so we pass a no-op
@@ -287,7 +280,7 @@ fn stream_poll_write(
 ///
 /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this method
 /// always returns `Poll::Ready(Ok())`.
-fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_flush(cx)
@@ -302,7 +295,7 @@ fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), E
 ///
 /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
 /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
-fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let this = unsafe { &mut *(data as *mut Grouped<TcpStreamSocket>) };
 
     Pin::new(&mut this.sock).poll_close(cx)
@@ -356,7 +349,7 @@ impl SocketGroupInner {
     /// [`TcpSocketExt::local_addr()`] method.
     ///
     /// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
-    fn bind(this: &Rc<Poller<Self>>, addr: SocketAddr) -> Result<TcpListener, Errno> {
+    fn bind(this: &Rc<Poller<Self>>, addr: SocketAddr) -> Result<TcpListener> {
         let mut listener = Grouped::new(this.clone(), TcpListenerSocket::bind(addr)?);
 
         to_result!(unsafe {
@@ -375,7 +368,7 @@ impl SocketGroupInner {
     }
 
     /// Adds a new incoming connection producing a [`TcpStream`] attached to this [`SocketGroup`].
-    fn add(this: &Rc<Poller<Self>>, accepted: Accepted) -> Result<TcpStream, Errno> {
+    fn add(this: &Rc<Poller<Self>>, accepted: Accepted) -> Result<TcpStream> {
         let mut stream = Grouped::new(this.clone(), accepted.into_socket());
 
         to_result!(unsafe {
@@ -399,7 +392,7 @@ impl SocketGroupInner {
         this: &Rc<Poller<Self>>,
         addr: SocketAddr,
         opts: &spdk_sock_opts,
-    ) -> Result<TcpStream, Errno> {
+    ) -> Result<TcpStream> {
         let mut stream = Grouped::new_in_place(this.clone(), |stream| {
             TcpStreamSocket::connect_in_place(stream, addr, opts)
         });
@@ -423,7 +416,7 @@ impl SocketGroupInner {
     /// This method is called from the [`Grouped<T: AsRawSock>::drop()`] method when a
     /// [`TcpListener`] or [`TcpStream`] (via [`RawTcpListener`] or [`RawTcpStream`], respectively)
     /// group member is dropped. It is not necessary to manually call this method.
-    fn remove<T>(&self, sock: &T) -> Result<(), Errno>
+    fn remove<T>(&self, sock: &T) -> Result<()>
     where
         T: AsRawSock,
     {
@@ -469,7 +462,7 @@ impl SocketGroup {
     /// returned.
     ///
     /// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
-    pub async fn bind<A: ToSocketAddrs>(&self, addrs: A) -> Result<TcpListener, Errno> {
+    pub async fn bind<A: ToSocketAddrs>(&self, addrs: A) -> Result<TcpListener> {
         for addr in addrs.to_socket_addr().await? {
             match SocketGroupInner::bind(&self.0, addr) {
                 Ok(listener) => return Ok(listener),
@@ -486,11 +479,7 @@ impl SocketGroup {
     /// If `addr` yields multiple socket addresses, `connect` will attempt to connect to each until
     /// one succeeds and returns a stream. If no address can be successfully connected, the error
     /// from the last connection attempt is returned.
-    pub async fn connect(
-        &self,
-        addr: SocketAddr,
-        opts: &spdk_sock_opts,
-    ) -> Result<TcpStream, Errno> {
+    pub async fn connect(&self, addr: SocketAddr, opts: &spdk_sock_opts) -> Result<TcpStream> {
         SocketGroupInner::connect(&self.0, addr, opts).await
     }
 
@@ -505,7 +494,7 @@ impl SocketGroup {
     /// let listener = group.bind("127.0.0.1:8080").await?;
     /// let remote = group.add(listener.accept().await?)?;
     /// ```
-    pub fn add(&self, accepted: Accepted) -> Result<TcpStream, Errno> {
+    pub fn add(&self, accepted: Accepted) -> Result<TcpStream> {
         SocketGroupInner::add(&self.0, accepted)
     }
 }

--- a/spdk/src/net/listener.rs
+++ b/spdk/src/net/listener.rs
@@ -10,7 +10,8 @@ use futures::{Stream, StreamExt};
 use spdk_sys::{spdk_sock, spdk_sock_accept, spdk_sock_close, spdk_sock_listen};
 
 use crate::{
-    errors::{self, EAGAIN, EBADF, EINVAL, Errno, errno},
+    Result,
+    errors::{EAGAIN, EBADF, EINVAL, errno},
     net::accept_polled_stream,
     task::Polled,
     to_result,
@@ -44,7 +45,7 @@ impl<'a> Incoming<'a> {
 }
 
 impl<'a> Stream for Incoming<'a> {
-    type Item = Result<Accepted, Errno>;
+    type Item = Result<Accepted>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         unsafe {
@@ -127,7 +128,7 @@ pub(crate) struct TcpListenerSocket {
 
 impl TcpListenerSocket {
     /// Creates a new [`TcpListenerSocket`] bound to the specified socket address.
-    pub(crate) fn bind(addr: SocketAddr) -> Result<Self, Errno> {
+    pub(crate) fn bind(addr: SocketAddr) -> Result<Self> {
         let sock = unsafe { spdk_sock_listen(addr.ip().as_ptr(), addr.port() as i32, ptr::null()) };
 
         if !sock.is_null() {
@@ -146,7 +147,7 @@ impl TcpListenerSocket {
     pub(crate) fn poll_accept(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<Accepted, Errno>> {
+    ) -> Poll<Result<Accepted>> {
         let accepted = unsafe { spdk_sock_accept(self.sock) };
 
         if !accepted.is_null() {
@@ -208,7 +209,7 @@ pub(crate) struct RawTcpListenerVtable {
     pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
 
     /// Polls the [`RawTcpListener`] for an incoming connection.
-    pub(crate) poll_accept: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<Accepted, Errno>>,
+    pub(crate) poll_accept: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<Accepted>>,
 
     /// Drops the [`RawTcpListener`].
     pub(crate) drop: unsafe fn(*const ()),
@@ -237,7 +238,7 @@ impl RawTcpListener {
     ///
     /// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
     /// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a [`TcpStream`].
-    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Accepted>> {
         unsafe { (self.vtable.poll_accept)(self.data, cx) }
     }
 }
@@ -281,7 +282,7 @@ impl TcpListener {
     /// If `addr` yields multiple socket address, `bind` will attempt listen on each until one
     /// succeeds and returns a listener. If no address can be successfully bound, `Err(EINVAL)` is
     /// returned.
-    pub async fn bind<A: ToSocketAddrs>(addrs: A) -> Result<Self, errors::Errno> {
+    pub async fn bind<A: ToSocketAddrs>(addrs: A) -> Result<Self> {
         for addr in addrs.to_socket_addr().await? {
             match bind_polled_listener(addr).ok() {
                 Some(listener) => return Ok(listener),
@@ -312,7 +313,7 @@ impl TcpListener {
     /// [`Thread`]: crate::thread::Thread
     /// [`into`]: std::convert::Into::into
     /// [`TcpStream`]: super::TcpStream
-    pub async fn accept(&mut self) -> Result<Accepted, Errno> {
+    pub async fn accept(&mut self) -> Result<Accepted> {
         self.incoming().next().await.unwrap_or(Err(EBADF))
     }
 

--- a/spdk/src/net/polled.rs
+++ b/spdk/src/net/polled.rs
@@ -1,5 +1,6 @@
 //! Contains the SPDK poller based TCP listener and stream implementations.
 use std::{
+    io::{IoSlice, IoSliceMut},
     mem::ManuallyDrop,
     pin::Pin,
     task::{Context, Poll},
@@ -7,7 +8,7 @@ use std::{
 
 use spdk_sys::{spdk_sock, spdk_sock_opts};
 
-use crate::{errors::Errno, task::Poller};
+use crate::{Result, task::Poller};
 
 use super::{
     Accepted, AsRawSock, Connector, RawTcpListener, RawTcpListenerVtable, RawTcpStream,
@@ -35,7 +36,7 @@ fn listener_as_raw_sock(data: *const ()) -> *mut spdk_sock {
 /// If an incoming connection is available, this function returns `Poll<Ok(`[`Accepted`]`)>`. See
 /// the [`TcpListener::accept`] for details on converting the `Accepted` instance into a
 /// [`TcpStream`].
-fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted, Errno>> {
+fn listener_poll_accept(data: *const (), cx: &mut Context<'_>) -> Poll<Result<Accepted>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpListenerSocket>) });
 
@@ -69,7 +70,7 @@ fn listener_vtable() -> &'static RawTcpListenerVtable {
 /// [`TcpSocketExt::local_addr()`] method.
 ///
 /// [`TcpSocketExt::local_addr()`]: crate::net::TcpSocketExt::local_addr
-pub(crate) fn bind_polled_listener(addr: SocketAddr) -> Result<TcpListener, Errno> {
+pub(crate) fn bind_polled_listener(addr: SocketAddr) -> Result<TcpListener> {
     let listener = Poller::new(TcpListenerSocket::bind(addr)?);
 
     // SAFETY: The `vtable` matches the `data` pointer type.
@@ -98,7 +99,7 @@ fn stream_as_raw_sock(data: *const ()) -> *mut spdk_sock {
 ///
 /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
 /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
-fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -116,11 +117,7 @@ fn stream_poll_connected(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(
 /// available and `Poll::Pending` if no data was available.
 ///
 /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
-fn stream_poll_read(
-    data: *const (),
-    cx: &mut Context<'_>,
-    buf: &mut [u8],
-) -> Poll<Result<usize, Errno>> {
+fn stream_poll_read(data: *const (), cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -141,8 +138,8 @@ fn stream_poll_read(
 fn stream_poll_read_vectored(
     data: *const (),
     cx: &mut Context<'_>,
-    bufs: &mut [std::io::IoSliceMut<'_>],
-) -> Poll<Result<usize, Errno>> {
+    bufs: &mut [IoSliceMut<'_>],
+) -> Poll<Result<usize>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -160,11 +157,7 @@ fn stream_poll_read_vectored(
 /// written and `Poll::Pending` data cannot currently be written.
 ///
 /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
-fn stream_poll_write(
-    data: *const (),
-    cx: &mut Context<'_>,
-    buf: &[u8],
-) -> Poll<Result<usize, Errno>> {
+fn stream_poll_write(data: *const (), cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -185,8 +178,8 @@ fn stream_poll_write(
 fn stream_poll_write_vectored(
     data: *const (),
     cx: &mut Context<'_>,
-    bufs: &[std::io::IoSlice<'_>],
-) -> Poll<Result<usize, Errno>> {
+    bufs: &[IoSlice<'_>],
+) -> Poll<Result<usize>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -202,7 +195,7 @@ fn stream_poll_write_vectored(
 ///
 /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this method
 /// always returns `Poll::Ready(Ok())`.
-fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -218,7 +211,7 @@ fn stream_poll_flush(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), E
 ///
 /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
 /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
-fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+fn stream_poll_close(data: *const (), cx: &mut Context<'_>) -> Poll<Result<()>> {
     let mut this =
         ManuallyDrop::new(unsafe { Poller::from_raw(data as *const Poller<TcpStreamSocket>) });
 
@@ -263,7 +256,7 @@ pub(crate) fn accept_polled_stream(accepted: Accepted) -> TcpStream {
 pub(crate) async fn connect_polled_stream(
     addr: SocketAddr,
     opts: &spdk_sock_opts,
-) -> Result<TcpStream, Errno> {
+) -> Result<TcpStream> {
     let stream = Poller::new_in_place(|stream| {
         TcpStreamSocket::connect_in_place(stream, addr, opts);
     });

--- a/spdk/src/net/socket.rs
+++ b/spdk/src/net/socket.rs
@@ -7,7 +7,7 @@ use std::{
 
 use spdk_sys::{spdk_sock, spdk_sock_getaddr};
 
-use crate::{errors::Errno, to_result};
+use crate::{Result, to_result};
 
 use super::SocketAddr;
 
@@ -30,7 +30,7 @@ where
 #[allow(private_bounds)]
 pub trait TcpSocketExt: AsRawSock {
     /// Returns the local address to which this TCP socket is bound.
-    fn local_addr(&self) -> Result<SocketAddr, Errno> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         let mut addr = [0u8; 46];
         let mut port = 0u16;
 
@@ -53,7 +53,7 @@ pub trait TcpSocketExt: AsRawSock {
 /// A trait defining methods common to TCP sockets with remote connections.
 pub trait TcpSocketRemote: TcpSocketExt {
     /// Returns the socket address of the remote connection.
-    fn peer_addr(&self) -> Result<SocketAddr, Errno> {
+    fn peer_addr(&self) -> Result<SocketAddr> {
         let mut addr = [0u8; 46];
         let mut port = 0u16;
 

--- a/spdk/src/net/stream.rs
+++ b/spdk/src/net/stream.rs
@@ -17,6 +17,7 @@ use spdk_sys::{
 };
 
 use crate::{
+    Result,
     errors::{EAGAIN, EBADF, EINPROGRESS, EINVAL, Errno, SUCCESS},
     task::Polled,
     to_result, to_result_size,
@@ -46,7 +47,7 @@ impl Connector {
     fn poll_connected(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<RawTcpStream, Errno>> {
+    ) -> Poll<Result<RawTcpStream>> {
         // SAFETY: We're mapping to a field of a pinned object.
         unsafe { Pin::map_unchecked_mut(self.as_mut(), |s| &mut s.0) }
             .as_pin_mut()
@@ -57,7 +58,7 @@ impl Connector {
 }
 
 impl Future for Connector {
-    type Output = Result<TcpStream, Errno>;
+    type Output = Result<TcpStream>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.poll_connected(cx).map_ok(TcpStream::new)
@@ -137,7 +138,7 @@ impl TcpStreamSocket {
     pub(crate) fn poll_connected(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Errno>> {
+    ) -> Poll<Result<()>> {
         // Call `spdk_sock_flush` to get an indication whether the connection is in-progress,
         // complete or failed.
         let res = to_result!(unsafe { spdk_sock_flush(self.sock) });
@@ -164,7 +165,7 @@ impl TcpStreamSocket {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         let res = to_result_size!(unsafe {
             spdk_sock_recv(self.sock, addr_of_mut!(*buf) as *mut _, buf.len())
         });
@@ -191,7 +192,7 @@ impl TcpStreamSocket {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         let res = to_result_size!(unsafe {
             spdk_sock_readv(self.sock, bufs as *mut _ as *mut IoVec, bufs.len() as i32)
         });
@@ -218,7 +219,7 @@ impl TcpStreamSocket {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         let iov = IoSlice::new(buf);
         let res =
             to_result_size!(unsafe { spdk_sock_writev(self.sock, addr_of!(iov) as *mut IoVec, 1) });
@@ -245,7 +246,7 @@ impl TcpStreamSocket {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         let res = to_result_size!(unsafe {
             spdk_sock_writev(self.sock, bufs as *const _ as *mut IoVec, bufs.len() as i32)
         });
@@ -266,10 +267,7 @@ impl TcpStreamSocket {
     ///
     /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this
     /// method always returns `Poll::Ready(Ok())`.
-    pub(crate) fn poll_flush(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Errno>> {
+    pub(crate) fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
         Poll::Ready(Ok(()))
     }
 
@@ -279,10 +277,7 @@ impl TcpStreamSocket {
     ///
     /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
     /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
-    pub(crate) fn poll_close(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Errno>> {
+    pub(crate) fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
         Poll::Ready(to_result!(unsafe {
             spdk_sock_close(&mut self.sock as *mut _)
         }))
@@ -333,33 +328,27 @@ pub(crate) struct RawTcpStreamVtable {
     pub(crate) as_raw_sock: unsafe fn(*const ()) -> *mut spdk_sock,
 
     /// Polls the connection state of the [`RawTcpStream`].
-    pub(crate) poll_connected: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    pub(crate) poll_connected: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<()>>,
 
     /// Attempts to read from the [`RawTcpStream`].
-    #[allow(clippy::type_complexity)]
-    pub(crate) poll_read:
-        unsafe fn(*const (), &mut Context<'_>, &mut [u8]) -> Poll<Result<usize, Errno>>,
+    pub(crate) poll_read: unsafe fn(*const (), &mut Context<'_>, &mut [u8]) -> Poll<Result<usize>>,
 
     /// Attempts to read from the [`RawTcpStream`] into multiple buffers.
-    #[allow(clippy::type_complexity)]
     pub(crate) poll_read_vectored:
-        unsafe fn(*const (), &mut Context<'_>, &mut [IoSliceMut]) -> Poll<Result<usize, Errno>>,
+        unsafe fn(*const (), &mut Context<'_>, &mut [IoSliceMut]) -> Poll<Result<usize>>,
 
     /// Attempts to write to the [`RawTcpStream`].
-    #[allow(clippy::type_complexity)]
-    pub(crate) poll_write:
-        unsafe fn(*const (), &mut Context<'_>, &[u8]) -> Poll<Result<usize, Errno>>,
+    pub(crate) poll_write: unsafe fn(*const (), &mut Context<'_>, &[u8]) -> Poll<Result<usize>>,
 
     /// Attempts to write to the [`RawTcpStream`] from multiple buffers.
-    #[allow(clippy::type_complexity)]
     pub(crate) poll_write_vectored:
-        unsafe fn(*const (), &mut Context<'_>, &[IoSlice]) -> Poll<Result<usize, Errno>>,
+        unsafe fn(*const (), &mut Context<'_>, &[IoSlice]) -> Poll<Result<usize>>,
 
     /// Attempts to flush buffered data in the [`RawTcpStream`].
-    pub(crate) poll_flush: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    pub(crate) poll_flush: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<()>>,
 
     /// Attempts to close the [`RawTcpStream`].
-    pub(crate) poll_close: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<(), Errno>>,
+    pub(crate) poll_close: unsafe fn(*const (), &mut Context<'_>) -> Poll<Result<()>>,
 
     /// Drops the [`RawTcpStream`].
     pub(crate) drop: unsafe fn(*const ()),
@@ -388,7 +377,7 @@ impl RawTcpStream {
     ///
     /// This method returns `Poll::Ready(Ok())` if the stream is connected, `Poll::Pending` if the
     /// outgoing connection is pending, and `Poll::Ready(Err(`[`Errno`]`))` if the connection failed.
-    fn poll_connected(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    fn poll_connected(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         unsafe { (self.vtable.poll_connected)(self.data, cx) }
     }
 
@@ -404,7 +393,7 @@ impl RawTcpStream {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         unsafe { (self.vtable.poll_read)(self.data, cx, buf) }
     }
 
@@ -420,7 +409,7 @@ impl RawTcpStream {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         unsafe { (self.vtable.poll_read_vectored)(self.data, cx, bufs) }
     }
 
@@ -432,11 +421,7 @@ impl RawTcpStream {
     /// written and `Poll::Pending` data cannot currently be written.
     ///
     /// If the connection has failed, this method returns `Poll::Ready(Err(`[`Errno`]`))`.
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, Errno>> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
         unsafe { (self.vtable.poll_write)(self.data, cx, buf) }
     }
 
@@ -452,7 +437,7 @@ impl RawTcpStream {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice],
-    ) -> Poll<Result<usize, Errno>> {
+    ) -> Poll<Result<usize>> {
         unsafe { (self.vtable.poll_write_vectored)(self.data, cx, bufs) }
     }
 
@@ -462,7 +447,7 @@ impl RawTcpStream {
     ///
     /// The SPDK does not expose a means explicitly flush the buffer data in the socket, so this
     /// method always returns `Poll::Ready(Ok())`.
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         unsafe { (self.vtable.poll_flush)(self.data, cx) }
     }
 
@@ -472,7 +457,7 @@ impl RawTcpStream {
     ///
     /// This method returns `Poll::Ready(Ok())` if the socket was successfully closed, and
     /// `Poll::Ready(Err(`[`Errno`]`))` otherwise.
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Errno>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         unsafe { (self.vtable.poll_close)(self.data, cx) }
     }
 }
@@ -510,7 +495,7 @@ impl TcpStream {
     /// If `addr` yields multiple socket addresses, `connect` will attempt to connect to each until
     /// one succeeds and returns a stream. If no address can be successfully connected,
     /// the error from the last connection attempt is returned.
-    pub async fn connect<A: ToSocketAddrs>(addrs: A) -> Result<Self, Errno> {
+    pub async fn connect<A: ToSocketAddrs>(addrs: A) -> Result<Self> {
         let opts = unsafe {
             let mut opts = MaybeUninit::<spdk_sock_opts>::zeroed().assume_init();
 

--- a/spdk/src/nvmf/subsystem.rs
+++ b/spdk/src/nvmf/subsystem.rs
@@ -18,7 +18,8 @@ use spdk_sys::{
 };
 
 use crate::{
-    errors::{EINVAL, ENOENT, Errno},
+    Result,
+    errors::{EINVAL, ENOENT},
     nvme::TransportId,
     task::{Promise, Promissory},
     to_poll_pending_on_ok, to_result,
@@ -75,7 +76,7 @@ impl Subsystem {
     }
 
     /// Sets the serial number of the subsystem.
-    pub fn set_serial_number(&mut self, sn: &CStr) -> Result<(), Errno> {
+    pub fn set_serial_number(&mut self, sn: &CStr) -> Result<()> {
         unsafe {
             if spdk_nvmf_subsystem_set_sn(self.as_ptr(), sn.as_ptr()) < 0 {
                 return Err(EINVAL);
@@ -91,7 +92,7 @@ impl Subsystem {
     }
 
     /// Sets the model number of the subsystem.
-    pub fn set_model_number(&mut self, mn: &CStr) -> Result<(), Errno> {
+    pub fn set_model_number(&mut self, mn: &CStr) -> Result<()> {
         unsafe {
             if spdk_nvmf_subsystem_set_mn(self.as_ptr(), mn.as_ptr()) < 0 {
                 return Err(EINVAL);
@@ -136,7 +137,7 @@ impl Subsystem {
     }
 
     /// Adds a host NQN to the allowed list.
-    pub fn allow_host(&mut self, host_nqn: &CStr) -> Result<(), Errno> {
+    pub fn allow_host(&mut self, host_nqn: &CStr) -> Result<()> {
         unsafe {
             to_result!(spdk_nvmf_subsystem_add_host(
                 self.as_ptr(),
@@ -155,7 +156,7 @@ impl Subsystem {
     ///
     /// Returns `Ok(true)` if the host was removed from the allowed list, and
     /// `Ok(false)` if the host was not in the allowed list.
-    pub fn deny_host(&mut self, host_nqn: &CStr) -> Result<bool, Errno> {
+    pub fn deny_host(&mut self, host_nqn: &CStr) -> Result<bool> {
         let res = unsafe {
             to_result!(spdk_nvmf_subsystem_remove_host(
                 self.as_ptr(),
@@ -194,7 +195,7 @@ impl Subsystem {
     /// Starts the subsystem.
     ///
     /// This method transitions of the subsystem from the Inactive to Active state.
-    pub async fn start<'a>(&'a mut self) -> Result<(), Errno> {
+    pub async fn start<'a>(&'a mut self) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
@@ -219,7 +220,7 @@ impl Subsystem {
     /// Stops the subsystem.
     ///
     /// This method transitions of the subsystem from the Active to Inactive state.
-    pub async fn stop<'a>(&'a mut self) -> Result<(), Errno> {
+    pub async fn stop<'a>(&'a mut self) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
@@ -250,7 +251,7 @@ impl Subsystem {
     /// namespace are quiesced and incoming commands are queued until the
     /// subsystem is resumed. A namespace identifier of 0 indicates that no
     /// namespace is paused while `SPDK_NVME_GLOBAL_NS_TAG` pauses all namespaces.
-    pub async fn pause<'a>(&'a mut self, ns: u32) -> Result<(), Errno> {
+    pub async fn pause<'a>(&'a mut self, ns: u32) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
@@ -276,7 +277,7 @@ impl Subsystem {
     /// Resumes the subsystem.
     ///
     /// This method transitions of the subsystem from the Inactive to Paused state.
-    pub async fn resume<'a>(&'a mut self) -> Result<(), Errno> {
+    pub async fn resume<'a>(&'a mut self) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) =
@@ -302,7 +303,7 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to add a
     /// namespace.
-    pub fn add_namespace(&mut self, device_name: &CStr) -> Result<Namespace, Errno> {
+    pub fn add_namespace(&mut self, device_name: &CStr) -> Result<Namespace> {
         unsafe {
             let nsid = spdk_nvmf_subsystem_add_ns_ext(
                 self.as_ptr(),
@@ -326,7 +327,7 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to remove a
     /// namespace.
-    pub fn remove_namespace(&mut self, nsid: u32) -> Result<(), Errno> {
+    pub fn remove_namespace(&mut self, nsid: u32) -> Result<()> {
         unsafe { to_result!(spdk_nvmf_subsystem_remove_ns(self.as_ptr(), nsid)) }
     }
 
@@ -339,7 +340,7 @@ impl Subsystem {
     ///
     /// The subsystem must be in the Paused or Inactive states to add a
     /// listener.
-    pub async fn add_listener<'a>(&'a mut self, transport_id: &TransportId) -> Result<(), Errno> {
+    pub async fn add_listener<'a>(&'a mut self, transport_id: &TransportId) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
@@ -364,7 +365,7 @@ impl Subsystem {
     ///
     /// Returns `Ok(true)` if the listener was removed, and `Ok(false)` if no
     /// listener was listening on the given transport.
-    pub fn remove_listener(&mut self, transport_id: &TransportId) -> Result<bool, Errno> {
+    pub fn remove_listener(&mut self, transport_id: &TransportId) -> Result<bool> {
         let res = unsafe {
             to_result!(spdk_nvmf_subsystem_remove_listener(
                 self.as_ptr(),

--- a/spdk/src/nvmf/target.rs
+++ b/spdk/src/nvmf/target.rs
@@ -16,7 +16,8 @@ use spdk_sys::{
 };
 
 use crate::{
-    errors::{EBADF, EINPROGRESS, ENOMEM, EPERM, Errno},
+    Result,
+    errors::{EBADF, EINPROGRESS, ENOMEM, EPERM},
     nvme::{SPDK_NVME_GLOBAL_NS_TAG, TransportId},
     task::{Promise, Promissory},
     thread, to_poll_pending_on_err, to_result,
@@ -57,7 +58,7 @@ impl Builder {
 
     /// Creates a new [`Target`] instance that owns the underlying
     /// `spdk_nvmf_tgt` pointer.
-    pub fn build(self) -> Result<Target, Errno> {
+    pub fn build(self) -> Result<Target> {
         unsafe {
             match NonNull::new(spdk_nvmf_tgt_create(&self.0 as *const _ as *mut _)) {
                 Some(ptr) => Ok(Target(OwnershipState::Owned(ptr))),
@@ -126,7 +127,7 @@ unsafe impl Send for Target {}
 impl Target {
     /// Creates a new NVMe-oF target that owns the underlying `spdk_nvmf_tgt`
     /// pointer.
-    pub fn new(name: &str) -> Result<Self, Errno> {
+    pub fn new(name: &str) -> Result<Self> {
         Builder::new(name).build()
     }
 
@@ -194,7 +195,7 @@ impl Target {
     /// `Err(EPERM)` if called on a borrowed target and `Err(ENODEV)` if called
     /// on a target that neither owns nor borrows the underlying `spdk_nvmf_tgt`
     /// pointer.
-    pub async fn destroy(mut self) -> Result<(), Errno> {
+    pub async fn destroy(mut self) -> Result<()> {
         match self.0 {
             OwnershipState::Owned(_) => {
                 Promise::new()
@@ -221,7 +222,7 @@ impl Target {
     }
 
     /// Adds a transport to the target.
-    pub async fn add_transport<'a>(&'a mut self, transport: Transport) -> Result<(), Errno> {
+    pub async fn add_transport<'a>(&'a mut self, transport: Transport) -> Result<()> {
         let res = Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_status(p);
@@ -264,7 +265,7 @@ impl Target {
     }
 
     /// Enables the NVMe-oF Discovery Controller subsystem on this target.
-    pub fn enable_discovery(&mut self) -> Result<Subsystem, Errno> {
+    pub fn enable_discovery(&mut self) -> Result<Subsystem> {
         let mut discovery =
             self.add_subsystem(SPDK_NVMF_DISCOVERY_NQN, SubsystemType::Discovery, 0)?;
 
@@ -288,7 +289,7 @@ impl Target {
         nqn: &CStr,
         subtype: SubsystemType,
         num_ns: u32,
-    ) -> Result<Subsystem, Errno> {
+    ) -> Result<Subsystem> {
         let subsys = unsafe {
             spdk_nvmf_subsystem_create(self.as_ptr(), nqn.as_ptr(), subtype.into(), num_ns)
         };
@@ -301,7 +302,7 @@ impl Target {
     }
 
     /// Removes a subsystem from the target.
-    pub async fn remove_subsystem<'a>(&'a mut self, subsys: Subsystem) -> Result<(), Errno> {
+    pub async fn remove_subsystem<'a>(&'a mut self, subsys: Subsystem) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(|p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_ok(p);
@@ -329,7 +330,7 @@ impl Target {
     }
 
     /// Starts the subsystems on this target.
-    pub async fn start_subsystems(&mut self) -> Result<(), Errno> {
+    pub async fn start_subsystems(&mut self) -> Result<()> {
         for mut subsys in self.subsystems() {
             subsys.start().await?;
         }
@@ -338,7 +339,7 @@ impl Target {
     }
 
     /// Stops the subsystems on this target.
-    pub async fn stop_subsystems(&mut self) -> Result<(), Errno> {
+    pub async fn stop_subsystems(&mut self) -> Result<()> {
         for mut subsys in self.subsystems() {
             subsys.stop().await?;
         }
@@ -347,7 +348,7 @@ impl Target {
     }
 
     /// Pauses the subsystems on this target.
-    pub async fn pause_subsystems(&mut self) -> Result<(), Errno> {
+    pub async fn pause_subsystems(&mut self) -> Result<()> {
         for mut subsys in self.subsystems() {
             subsys.pause(SPDK_NVME_GLOBAL_NS_TAG).await?;
         }
@@ -356,7 +357,7 @@ impl Target {
     }
 
     /// Resumes the subsystems on this target.
-    pub async fn resume_subsystems(&mut self) -> Result<(), Errno> {
+    pub async fn resume_subsystems(&mut self) -> Result<()> {
         for mut subsys in self.subsystems() {
             subsys.resume().await?;
         }
@@ -365,7 +366,7 @@ impl Target {
     }
 
     /// Begins accepting new connections on the specified transport.
-    pub fn listen(&mut self, transport_id: &TransportId) -> Result<(), Errno> {
+    pub fn listen(&mut self, transport_id: &TransportId) -> Result<()> {
         unsafe {
             let mut opts = MaybeUninit::uninit();
 

--- a/spdk/src/nvmf/transport.rs
+++ b/spdk/src/nvmf/transport.rs
@@ -18,6 +18,7 @@ use spdk_sys::{
 };
 
 use crate::{
+    Result,
     errors::{EINVAL, ENODEV, ENOMEM, EPERM, Errno},
     task::{Promise, Promissory},
     thread, to_poll_pending_on_ok,
@@ -101,7 +102,7 @@ unsafe impl Send for Builder {}
 
 impl Builder {
     /// Creates a new builder for the given transport type.
-    pub fn new(transport_type: TransportType) -> Result<Self, Errno> {
+    pub fn new(transport_type: TransportType) -> Result<Self> {
         unsafe {
             let mut opts = MaybeUninit::uninit();
             let transport_name: &CStr = transport_type.into();
@@ -122,7 +123,7 @@ impl Builder {
     }
 
     /// Creates the configured `Transport`.
-    pub async fn build(self) -> Result<Transport, Errno> {
+    pub async fn build(self) -> Result<Transport> {
         Promise::new()
             .request(move |p| {
                 let (cb_fn, cb_arg) = Promissory::callback_with_object(p);
@@ -347,7 +348,7 @@ impl Transport {
     /// `Err(EPERM)` if called on a borrowed transport and `Err(ENODEV)` if
     /// called on a transport that neither owns nor borrows the underlying
     /// `spdk_nvmf_transport` pointer.
-    pub async fn destroy(mut self) -> Result<(), Errno> {
+    pub async fn destroy(mut self) -> Result<()> {
         match self.0 {
             OwnershipState::Borrowed(_) => Err(EPERM),
             OwnershipState::None => Err(ENODEV),
@@ -392,7 +393,7 @@ impl Drop for Transport {
 impl TryFrom<*mut spdk_nvmf_transport> for Transport {
     type Error = Errno;
 
-    fn try_from(ptr: *mut spdk_nvmf_transport) -> Result<Self, Self::Error> {
+    fn try_from(ptr: *mut spdk_nvmf_transport) -> Result<Self> {
         match NonNull::new(ptr) {
             Some(ptr) => Ok(Self(OwnershipState::Owned(ptr))),
             None => Err(ENOMEM),
@@ -403,7 +404,7 @@ impl TryFrom<*mut spdk_nvmf_transport> for Transport {
 impl TryFrom<*const spdk_nvmf_transport> for Transport {
     type Error = Errno;
 
-    fn try_from(ptr: *const spdk_nvmf_transport) -> Result<Self, Self::Error> {
+    fn try_from(ptr: *const spdk_nvmf_transport) -> Result<Self> {
         match NonNull::new(ptr as *mut _) {
             Some(ptr) => Ok(Self(OwnershipState::Borrowed(ptr))),
             None => Err(ENOMEM),

--- a/spdk/src/runtime/reactor.rs
+++ b/spdk/src/runtime/reactor.rs
@@ -8,7 +8,8 @@ use futures::{
 use spdk_sys::{spdk_event_allocate, spdk_event_call};
 
 use crate::{
-    errors::{ENOMEM, Errno},
+    Result,
+    errors::ENOMEM,
     task::{self, Executor, JoinHandle},
     thread::Thread,
 };
@@ -104,7 +105,7 @@ impl Reactor {
         self.0
     }
 
-    pub fn send_event<F>(&self, f: F) -> Result<(), Errno>
+    pub fn send_event<F>(&self, f: F) -> Result<()>
     where
         F: FnOnce() + 'static,
     {

--- a/spdk/src/runtime/runtime.rs
+++ b/spdk/src/runtime/runtime.rs
@@ -18,6 +18,7 @@ use static_init::dynamic;
 use ternary_rs::if_else;
 
 use crate::{
+    Result,
     errors::{EINVAL, Errno},
     runtime::{Reactor, reactors},
     task::{LocalTask, RcTask},
@@ -76,7 +77,7 @@ impl Builder {
     }
 
     /// Returns a new builder with values initialized from the command line.
-    pub fn from_cmdline() -> Result<Self, Errno> {
+    pub fn from_cmdline() -> Result<Self> {
         let argv: Vec<*const c_char> = ARGV_CSTRING.iter().map(|a| a.as_ptr()).collect();
         let mut builder = Self::new();
 
@@ -195,7 +196,7 @@ impl Runtime {
     }
 
     /// Returns a new runtime initialized from the command line.
-    pub fn from_cmdline() -> Result<Self, Errno> {
+    pub fn from_cmdline() -> Result<Self> {
         Ok(Builder::from_cmdline()?
             .with_name(APP_NAME.as_c_str())
             .build())

--- a/spdk/src/task/promise.rs
+++ b/spdk/src/task/promise.rs
@@ -12,6 +12,7 @@ use std::{
 use libc::c_void;
 
 use crate::{
+    Result,
     errors::{EINVAL, Errno},
     thread::Thread,
     to_result,
@@ -60,7 +61,7 @@ where
     /// If a completion function is invoked before the start function returns, the promise
     /// transitions from the `Requesting` state to the `Kept` state directly. Otherwise, the promise
     /// transitions from the `Requesting` state to the `Waiting` state.
-    Kept(Result<T, Errno>),
+    Kept(Result<T>),
 
     /// The promisee has received the promised result.
     ///
@@ -97,7 +98,7 @@ where
     /// Sets the state and result of the operation to [`Kept`].
     ///
     /// [`Kept`]: Self::Kept
-    fn set_kept(&mut self, res: Result<T, Errno>) -> Self {
+    fn set_kept(&mut self, res: Result<T>) -> Self {
         match self {
             Self::Requesting | Self::Waiting(_) => mem::replace(self, Self::Kept(res)),
             _ => panic!("set_kept called in unexpected state: {:?}", self),
@@ -198,7 +199,7 @@ where
     }
 
     /// Sets the state and result of the operation to [`PromiseState::Kept`].
-    fn set_kept(&self, res: Result<R, Errno>) -> PromiseState<R> {
+    fn set_kept(&self, res: Result<R>) -> PromiseState<R> {
         self.state.borrow_mut().set_kept(res)
     }
 
@@ -216,7 +217,7 @@ where
     }
 
     /// Sets the result of the operation and awakens the [`Promise`] awaiting the result.
-    pub fn set_result(rc_self: Rc<Self>, res: Result<R, Errno>) {
+    pub fn set_result(rc_self: Rc<Self>, res: Result<R>) {
         assert!(
             rc_self.thread.is_current(),
             "set_result called from wrong thread"
@@ -365,7 +366,7 @@ impl<R, C> Future for FuturePromise<R, C>
 where
     R: Debug,
 {
-    type Output = Result<R, Errno>;
+    type Output = Result<R>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let state = self.0.poll_state(cx);
@@ -476,9 +477,9 @@ where
     }
 
     /// Begins the asynchronous operation to fulfill the promise.
-    pub fn request<S>(mut self, start_fn: S) -> impl Future<Output = Result<R, Errno>>
+    pub fn request<S>(mut self, start_fn: S) -> impl Future<Output = Result<R>>
     where
-        S: FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R, Errno>>,
+        S: FnOnce(&mut Rc<Promissory<R, C>>) -> Poll<Result<R>>,
     {
         self.0.set_requesting();
 

--- a/spdk/src/thread.rs
+++ b/spdk/src/thread.rs
@@ -32,7 +32,8 @@ use spdk_sys::{
 };
 
 use crate::{
-    errors::{ENOMEM, Errno},
+    Result,
+    errors::ENOMEM,
     runtime::CpuSet,
     task::{self, Executor, JoinHandle},
     to_result,
@@ -70,7 +71,7 @@ impl Thread {
     /// The thread object returned is owned by the caller. When dropped, the
     /// thread will be marked for exit causing any further processing requests
     /// on this thread to fail.
-    pub fn new(name: &CStr, cpuset: &CpuSet) -> Result<Self, Errno> {
+    pub fn new(name: &CStr, cpuset: &CpuSet) -> Result<Self> {
         let t = unsafe { spdk_thread_create(name.as_ptr(), cpuset.as_ptr()) };
 
         match NonNull::new(t) {
@@ -288,7 +289,7 @@ impl Thread {
     ///
     /// [`EIO`]: crate::errors::EIO
     /// [`ENOMEM`]: crate::errors::ENOMEM
-    pub fn send_msg<F>(&self, f: F) -> Result<(), Errno>
+    pub fn send_msg<F>(&self, f: F) -> Result<()>
     where
         F: FnOnce(),
     {


### PR DESCRIPTION
Adds `spdk::Result<T>` as a type alias of `std::result::Result<T, spdk::errors::Errno>`.