### PR TITLE
feat(bdev): uses the builder pattern to create new custom `BDev` instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: rustdoc
     name: rustdoc
     description: Check rustdoc for correctness
-    entry: "env RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --all-features --document-private-items --color always --open"
+    entry: "env RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --all-features --document-private-items --color always"
     language: system
     pass_filenames: false
   - id: clippy

--- a/spdk-macros/src/lib.rs
+++ b/spdk-macros/src/lib.rs
@@ -8,76 +8,48 @@ mod module;
 
 use proc_macro::TokenStream;
 
-/// Derives the [`Parser`] trait for a struct defining command-line arguments in
-/// addition to the standard SPDK Application Framework arguments.
+/// Derives the [`Parser`] trait for a struct defining command-line arguments in addition to the
+/// standard SPDK Application Framework arguments.
 ///
-/// This macro provides simple command-line argument parsing for SPDK
-/// applications and integrates with the [`macro@main`] macro. It allows an
-/// application to extend the set of command-line arguments supported by the
-/// SPDK Event Framework. The derived struct will implement the [`Parser`] trait
-/// and its `parse` method can be passed to the [`macro@main`] macro.
+/// This macro provides simple command-line argument parsing for SPDK applications and integrates
+/// with the [`macro@main`] macro. It allows an application to extend the set of command-line
+/// arguments supported by the SPDK Event Framework. The derived struct will implement the
+/// [`Parser`] trait and its `parse` method can be passed to the [`macro@main`] macro.
 ///
-/// If you need more advanced argument parsing, consider using a crate like
-/// [`clap`] and create a runtime using the [`Builder`] type.
+/// If you need more advanced argument parsing, consider using a crate like [`clap`] and create a
+/// runtime using the [`Builder`] type.
 ///
 /// # Field Types
 ///
-/// The type of each field in the derived struct must implement the [`FromStr`]
-/// trait.
+/// The type of each field in the derived struct must implement the [`FromStr`] trait.
 ///
-/// Boolean fields are treated as flags and will be set to `true` if present on
-/// the command-line. The option supports an optional value containing `true` or
-/// `false` to explicitly set the value.
+/// Boolean fields are treated as flags and will be set to `true` if present on the command-line.
+/// The option supports an optional value containing `true` or `false` to explicitly set the value.
 ///
 /// # Attributes
 ///
-/// The optional `spdk_arg` helper attribute can be used the customize the
-/// command-line behavior. The following metadata is supported by this
-/// attribute:
+/// The optional `spdk_arg` helper attribute can be used the customize the command-line behavior.
+/// The following metadata is supported by this attribute:
 ///
-/// * `short`: The short name of the argument, e.g. `short = 'C'`. If not present,
-///   no short argument will be generated.
-/// * `long`: The long name of the argument, e.g. `long = "block-count"`. If not
-///   present, the field name will be converted to a long argument by replacing
-///   any underscores (`'_'`) with dashes (`'-'`).
-/// * `default`: The default value for the argument, e.g. `default = 512`. If
-///   not present, the field type must implement the [`Default`] trait.
-/// * `value_name`: The name of the value for the argument that will appear in
-///   the usage help text, e.g. `value_name = "SIZE"`. If not present, the value
-///   name will be derived from the field name by converting to uppercase and
-///   replacing underscores with dashes.
+/// * `short`: The short name of the argument, e.g. `short = 'C'`. If not present, no short argument
+///   will be generated.
+/// * `long`: The long name of the argument, e.g. `long = "block-count"`. If not present, the field
+///   name will be converted to a long argument by replacing any underscores (`'_'`) with dashes
+///   (`'-'`).
+/// * `default`: The default value for the argument, e.g. `default = 512`. If not present, the field
+///   type must implement the [`Default`] trait.
+/// * `value_name`: The name of the value for the argument that will appear in the usage help text,
+///   e.g. `value_name = "SIZE"`. If not present, the value name will be derived from the field name
+///   by converting to uppercase and replacing underscores with dashes.
 ///
 /// # Help Text
 ///
-/// The help text for the derived struct will be generated from the doc comments
-/// for each field.
+/// The help text for the derived struct will be generated from the doc comments for each field.
 ///
 /// # Usage
 ///
 /// ```no_run
-/// use std::path::PathBuf;
-/// use spdk::{self, cli::Parser};
-///
-/// #[derive(Debug, Parser)]
-/// struct Args {
-///     /// Path to the block device to use.
-///     #[spdk_arg(short = 'D')]
-///     device_path: PathBuf,
-///
-///     /// The block size of the device in bytes.
-///     #[spdk_arg(default = 512)]
-///     block_size: u32,
-///
-///     /// If specified, creates a new block device.
-///     create_new: bool,
-/// }
-///
-/// #[spdk::main(cli_args = Args::parse())]
-/// async fn main() {
-///     let args = Args::get();
-///
-///     println!("{:#?}", args);
-/// }
+#[doc = include_str!("../../spdk/examples/cli.rs")]
 /// ```
 ///
 /// The following help text will be generated for the above example:
@@ -150,25 +122,23 @@ pub fn parser(input: TokenStream) -> TokenStream {
     cli::DeriveParser::new().derive(input)
 }
 
-/// Marks the main entry point of an application using the SPDK Application
-/// Framework.
+/// Marks the main entry point of an application using the SPDK Application Framework.
 ///
 /// # Notes
 ///
-/// This macro is for applications that do not require a complex setup. Consider
-/// using [`Builder`](../spdk/runtime/struct.Builder.html) to create a
-/// [`Runtime`](../spdk/runtime/struct.Runtime.html) directly if this macro does
-/// not meet your needs.
+/// This macro is for applications that do not require a complex setup. Consider using
+/// [`Builder`](../spdk/runtime/struct.Builder.html) to create a
+/// [`Runtime`](../spdk/runtime/struct.Runtime.html) directly if this macro does not meet your
+/// needs.
 ///
-/// The [`Runtime`](../spdk/runtime/struct.Runtime.html) created by this macro
-/// is initialized from the command line arguments supported by the
+/// The [`Runtime`](../spdk/runtime/struct.Runtime.html) created by this macro is initialized from
+/// the command line arguments supported by the
 /// [`spdk_app_parse_args`](../spdk_sys/fn.spdk_app_parse_args.html) function.
 ///
 /// # Attributes
 ///
-/// The `cli_args` attribute is used with the `Parser` trait to specify the
-/// parsing function for a struct defining command-line arguments. See the
-/// [`Parser`] derive macro for more information.
+/// The `cli_args` attribute is used with the `Parser` trait to specify the parsing function for a
+/// struct defining command-line arguments. See the [`Parser`] derive macro for more information.
 ///
 /// # Usage
 ///
@@ -185,127 +155,36 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Marks a struct as a SPDK block device module.
 ///
-/// This attribute macro creates a singleton instance of type [`Module<T>`] for
-/// the target struct and registers it with the SPDK block device module list.
+/// This attribute macro creates a singleton instance of type [`Module<T>`] for the target struct
+/// and registers it with the SPDK block device module list.
 ///
-/// The singleton instance can be accessed using the [`instance()`] method of
-/// the [`ModuleInstance`] trait.
+/// The singleton instance can be accessed using the [`instance()`] method of the [`ModuleInstance<T>`]
+/// trait.
 ///
-/// BDev implementors call the [`new_bdev()`] method of the `ModuleInstance`
+/// BDev implementors call the [`new_bdev()`] or [`new_bdev_in_place()`] methods of the `ModuleOps`
 /// trait to create a new block device instance.
+///
+/// # Attributes
+///
+/// The `product_name` attribute can be used to specify a product name for the block device. If not
+/// specified, the product name will be derived from the struct name by removing the `Module`
+/// suffix, converting to title case and appending "Disk".
 ///
 /// # Example
 ///
-/// The following example creates a block device module for a device that
-/// ignores writes and returns zeroed buffers for reads:
+/// The following example creates a block device module for a device that ignores writes and returns
+/// zeroed buffers for reads:
 ///
 ///
-/// ```rust
-/// use std::io::Write;
-///
-/// use spdk::{
-///     bdev::{
-///         BDevIo,
-///         BDevIoChannelOps,
-///         BDevOps,
-///         IoStatus,
-///         IoType,
-///         ModuleInstance,
-///         ModuleOps,
-///     },
-///     block::{
-///         Device,
-///         Owned,
-///     },
-///     dma,
-///     errors::Errno
-/// };
-///
-/// /// Implements the NullRs block device module.
-/// #[spdk::module]
-/// #[derive(Debug, Default)]
-/// struct NullRsModule;
-///
-/// impl ModuleOps for NullRsModule {
-///     type IoContext = ();
-/// }
-///
-/// /// Implements the NullRs block device I/O channel. It ignores write requests
-/// /// and returns zeroed buffers for read requests.
-/// #[derive(Debug, Default)]
-/// struct NullRsChannel;
-///
-/// impl BDevIoChannelOps for NullRsChannel {
-///     type IoContext = ();
-///
-///     fn submit_request(&self, io: BDevIo<Self::IoContext>) {
-///         if io.io_type() == IoType::Read {
-///             let dst = io.buffers_mut();
-///
-///             dst[0].fill(0);
-///         }
-///
-///         io.complete(IoStatus::Success);
-///     }
-/// }
-///
-/// /// Implements the NullRs block device.
-/// #[derive(Default)]
-/// struct NullRs;
-///
-/// unsafe impl Send for NullRs {}
-/// unsafe impl Sync for NullRs {}
-///
-/// impl NullRs {
-///     /// Creates a new NullRs block device.
-///     pub fn try_new() -> spdk::Result<Device<Owned>> {
-///         let mut null = NullRsModule::new_bdev(c"null-rs", NullRs::default());
-///
-///         null.bdev.blocklen = 4096;
-///         null.bdev.blockcnt = 1;
-///
-///         null.register()?;
-///
-///         Ok(null.into_device())
-///     }
-/// }
-///
-/// impl BDevOps for NullRs {
-///     type IoChannel = NullRsChannel;
-///
-///     async fn destruct(&mut self) -> spdk::Result<()> {
-///         Ok(())
-///     }
-///
-///     fn io_type_supported(&self, io_type: IoType) -> bool {
-///         matches!(io_type, IoType::Read | IoType::Write)
-///     }
-/// }
-///
-/// /// A program that creates and writes to the NullRs block device.
-/// #[spdk::main]
-/// async fn main() {
-///     let null = NullRs::try_new().unwrap();
-///     let desc = null.open(true).await.unwrap();
-///     let mut ch = desc.io_channel().unwrap();
-///     let layout = null.layout_for_blocks(1).unwrap();
-///     let mut buf = dma::Buffer::new_zeroed(layout);
-///
-///     write!(buf.cursor_mut(), "Hello, World!").unwrap();
-///
-///     ch.write_at(&buf, 0).await.unwrap();
-///
-///     drop(ch);
-///     drop(desc);
-///     null.destroy().await.unwrap();
-/// }
-///
+/// ```no_run
+#[doc = include_str!("../../spdk/examples/module_null.rs")]
 /// ```
 ///
 /// [`instance()`]: ../spdk/bdev/trait.ModuleInstance.html#tymethod.instance
-/// [`new_bdev()`]: ../spdk/bdev/trait.ModuleInstance.html#tymethod.new_bdev
+/// [`new_bdev()`]: ../spdk/bdev/trait.ModuleOps.html#tymethod.new_bdev
+/// [`new_bdev()`]: ../spdk/bdev/trait.ModuleOps.html#tymethod.new_bdev_in_place
 /// [`Module<T>`]: ../spdk/bdev/struct.Module.html
-/// [`ModuleInstance`]: ../spdk/bdev/trait.ModuleInstance.html
+/// [`ModuleInstance<T>`]: ../spdk/bdev/trait.ModuleInstance.html
 #[cfg(feature = "bdev-module")]
 #[proc_macro_attribute]
 pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -314,8 +193,8 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Generates `Errno` constant definitions for the `errors` module of the `spdk` crate.
 ///
-/// The macro takes a comma-delimited list of simple expression assignments given by the
-/// regular expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`, and generates `Errno` constant
+/// The macro takes a comma-delimited list of simple expression assignments given by the regular
+/// expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`, and generates `Errno` constant
 /// definitions. The definitions include automatically generated documentation by passing the value
 /// to the [`strerror`] function.
 ///

--- a/spdk-macros/src/lib.rs
+++ b/spdk-macros/src/lib.rs
@@ -161,8 +161,10 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// The singleton instance can be accessed using the [`instance()`] method of the [`ModuleInstance<T>`]
 /// trait.
 ///
-/// BDev implementors call the [`new_bdev()`] or [`new_bdev_in_place()`] methods of the `ModuleOps`
-/// trait to create a new block device instance.
+/// BDev implementors call the [`new_bdev_builder()`] method of the `ModuleOps` trait to create a
+/// builder to specify the attributes of a new block device. The builder's [`build()`],
+/// [`build_with_context()`] or [`build_with_context_in_place()`] methods create and register the new
+/// BDev instance with the SPDK global block device list.
 ///
 /// # Attributes
 ///
@@ -181,8 +183,10 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [`instance()`]: ../spdk/bdev/trait.ModuleInstance.html#tymethod.instance
-/// [`new_bdev()`]: ../spdk/bdev/trait.ModuleOps.html#tymethod.new_bdev
-/// [`new_bdev()`]: ../spdk/bdev/trait.ModuleOps.html#tymethod.new_bdev_in_place
+/// [`new_bdev_builder()`]: ../spdk/bdev/trait.ModuleOps.html#tymethod.new_bdev
+/// [`build()`]: ../spdk/bdev/struct.BDevBuilder.html#tymethod.build
+/// [`build_with_context()`]: ../spdk/bdev/struct.BDevBuilder.html#tymethod.build_with_context
+/// [`build_with_context_in_place()`]: ../spdk/bdev/struct.BDevBuilder.html#tymethod.build_with_context_in_place
 /// [`Module<T>`]: ../spdk/bdev/struct.Module.html
 /// [`ModuleInstance<T>`]: ../spdk/bdev/trait.ModuleInstance.html
 #[cfg(feature = "bdev-module")]

--- a/spdk-macros/src/module.rs
+++ b/spdk-macros/src/module.rs
@@ -52,11 +52,19 @@ impl GenerateModule {
                     &#reg_var_ident.get().unwrap().module as *const _
                 }
 
-                fn new_bdev<B>(name: &::std::ffi::CStr, ctx: B) -> Box<::spdk::bdev::BDevImpl<B>>
+                fn new_bdev<C>(name: &::std::ffi::CStr, ctx: C) -> Box<::spdk::bdev::BDevImpl<C>>
                 where
-                    B: ::spdk::bdev::BDevOps
+                    C: ::spdk::bdev::BDevOps + Unpin
                 {
                     ::spdk::bdev::BDevImpl::new(name, Self::module(), ctx)
+                }
+
+                fn new_bdev_in_place<C, I>(name: &::std::ffi::CStr, init_fn: I) -> Box<::spdk::bdev::BDevImpl<C>>
+                where
+                    C: ::spdk::bdev::BDevOps,
+                    I: FnOnce(::std::pin::Pin<&mut ::std::mem::MaybeUninit<C>>)
+                {
+                    ::spdk::bdev::BDevImpl::new_in_place(name, Self::module(), init_fn)
                 }
             }
         };

--- a/spdk-macros/src/module.rs
+++ b/spdk-macros/src/module.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::LitCStr;
+use syn::{LitCStr, Meta, spanned::Spanned};
 
 pub(crate) struct GenerateModule {}
 
@@ -14,20 +14,63 @@ impl GenerateModule {
     }
 
     /// Generates the code for the `module` attribute macro.
-    pub(crate) fn generate(&mut self, _attr: TokenStream, item: TokenStream) -> TokenStream {
+    pub(crate) fn generate(&mut self, attr: TokenStream, item: TokenStream) -> TokenStream {
         let input = syn::parse_macro_input!(item as syn::ItemStruct);
         let module_ident = input.ident.clone();
-        let module_name = input
+        let module_basename = input
             .ident
             .to_string()
             .trim_end_matches("Module")
+            .to_string();
+        let module_name = module_basename
             .from_case(Case::UpperCamel)
             .to_case(Case::Snake);
+        let product_name = format!(
+            "{} Disk",
+            module_basename
+                .from_case(Case::UpperCamel)
+                .to_case(Case::Title)
+        );
+        let mut product_name_cstr = CString::new(product_name).unwrap();
         let module_ident_name = module_name.from_case(Case::Snake).to_case(Case::UpperSnake);
         let reg_var_ident = format_ident!("__{}_MODULE", module_ident_name);
         let module_name_ident = format_ident!("__{}_MODULE_NAME", module_ident_name);
         let module_name_cstr = CString::new(module_name).unwrap();
         let module_name_lit = LitCStr::new(&module_name_cstr, module_ident.span());
+
+        if !attr.is_empty() {
+            let meta = syn::parse_macro_input!(attr as Meta);
+
+            match &meta {
+                Meta::NameValue(nv) if nv.path.is_ident("product_name") => {
+                    let expr = &nv.value;
+
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(lit_str),
+                        ..
+                    }) = expr
+                    {
+                        product_name_cstr = CString::new(lit_str.value()).unwrap();
+                    } else {
+                        return syn::Error::new_spanned(expr, "expected string literal")
+                            .into_compile_error()
+                            .into();
+                    }
+                }
+                _ => {
+                    let message = format!(
+                        "unexpected attribute metadata: {}`",
+                        meta.span().source_text().unwrap()
+                    );
+
+                    return syn::Error::new(meta.span(), message)
+                        .into_compile_error()
+                        .into();
+                }
+            }
+        }
+
+        let product_name_lit = LitCStr::new(&product_name_cstr, module_ident.span());
 
         let output = quote! {
             #input
@@ -44,27 +87,12 @@ impl GenerateModule {
             }
 
             impl ::spdk::bdev::ModuleInstance<#module_ident> for #module_ident {
-                fn instance() -> &'static #module_ident {
-                    &#reg_var_ident.get().unwrap().instance
+                fn instance() -> &'static ::spdk::bdev::Module<#module_ident> {
+                    &#reg_var_ident.get().unwrap()
                 }
 
-                fn module() -> *const ::spdk_sys::spdk_bdev_module {
-                    &#reg_var_ident.get().unwrap().module as *const _
-                }
-
-                fn new_bdev<C>(name: &::std::ffi::CStr, ctx: C) -> Box<::spdk::bdev::BDevImpl<C>>
-                where
-                    C: ::spdk::bdev::BDevOps + Unpin
-                {
-                    ::spdk::bdev::BDevImpl::new(name, Self::module(), ctx)
-                }
-
-                fn new_bdev_in_place<C, I>(name: &::std::ffi::CStr, init_fn: I) -> Box<::spdk::bdev::BDevImpl<C>>
-                where
-                    C: ::spdk::bdev::BDevOps,
-                    I: FnOnce(::std::pin::Pin<&mut ::std::mem::MaybeUninit<C>>)
-                {
-                    ::spdk::bdev::BDevImpl::new_in_place(name, Self::module(), init_fn)
+                fn product_name() -> &'static ::std::ffi::CStr {
+                    #product_name_lit
                 }
             }
         };

--- a/spdk-sys/build.rs
+++ b/spdk-sys/build.rs
@@ -252,6 +252,7 @@ fn main() {
         .wrap_static_fns_path(&spdk_wrappers)
         .wrap_unsafe_ops(true)
         .prepend_enum_name(false)
+        .rustified_enum("spdk_dif_.*")
         .generate_cstr(true)
         .layout_tests(false);
 

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -117,28 +117,14 @@ impl BDevIoChannelOps for EchoChannel {
 }
 
 /// Implements the Echo block device.
+#[derive(Default)]
 struct Echo {
     inner: Arc<EchoInner>,
 }
 
 impl Echo {
     fn try_new(name: &CStr) -> spdk::Result<Device<Owned>> {
-        let mut echo = EchoModule::new_bdev(name, Self::default());
-
-        echo.bdev.blocklen = 4096;
-        echo.bdev.blockcnt = 2;
-
-        echo.register()?;
-
-        Ok(echo.into_device())
-    }
-}
-
-impl Default for Echo {
-    fn default() -> Self {
-        Self {
-            inner: Arc::new(Default::default()),
-        }
+        EchoModule::new_bdev_builder(name, 4096, 2).build()
     }
 }
 

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -9,7 +9,7 @@ use async_condvar_fair::Condvar;
 use futures::future::join;
 use parking_lot::Mutex;
 use spdk::{
-    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps},
+    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleOps},
     block::{Device, IoType, Owned},
     dma,
     errors::ENOTSUP,

--- a/spdk/examples/module_echo.rs
+++ b/spdk/examples/module_echo.rs
@@ -60,9 +60,9 @@ impl EchoChannel {
         let dst_buf = io.buffers_mut();
 
         if offset_blocks == 0 {
-            // Some Virtual BDev read the first block to inspect
+            // Some Virtual BDevs read the first block to inspect
             // partition or other metadata to determine whether
-            // to claim the device. We imply return a block of
+            // to claim the device. We simply return a block of
             // zeros to prevent this BDev from claiming the device.
             dst_buf[0].fill(0);
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -43,14 +43,7 @@ unsafe impl Sync for NullRs {}
 impl NullRs {
     /// Creates a new NullRs block device.
     pub fn try_new() -> spdk::Result<Device<Owned>> {
-        let mut null = NullRsModule::new_bdev(c"null-rs", NullRs);
-
-        null.bdev.blocklen = 4096;
-        null.bdev.blockcnt = 1;
-
-        null.register()?;
-
-        Ok(null.into_device())
+        NullRsModule::new_bdev_builder(c"null-rs", 4096, 1).build()
     }
 }
 

--- a/spdk/examples/module_null.rs
+++ b/spdk/examples/module_null.rs
@@ -1,13 +1,13 @@
 use std::io::Write;
 
 use spdk::{
-    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps},
+    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleOps},
     block::{Device, IoType, Owned},
     dma,
 };
 
 /// Implements the NullRs block device module.
-#[spdk::module]
+#[spdk::module(product_name = "Null Disk")]
 #[derive(Debug, Default)]
 struct NullRsModule;
 

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use spdk::{
-    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleInstance, ModuleOps, malloc},
+    bdev::{BDevIo, BDevIoChannelOps, BDevOps, ModuleOps, malloc},
     block::{Any, Descriptor, Device, IoChannel, IoType, Owned},
     dma::{self},
     errors::ENOTSUP,

--- a/spdk/examples/module_passthru.rs
+++ b/spdk/examples/module_passthru.rs
@@ -99,31 +99,23 @@ impl BDevOps for PassthruRs {
 impl PassthruRs {
     pub fn try_new(base: Device<Any>, desc: Descriptor) -> spdk::Result<Device<Owned>> {
         let name = CString::new(format!("passthru-rs-{}", base.name().to_string_lossy())).unwrap();
-        let mut passthru = PassthruRsModule::new_bdev(name.as_c_str(), PassthruRs { base, desc });
 
-        let base = unsafe { &mut *passthru.ctx().base.as_ptr() };
-
-        passthru.bdev.write_cache = base.write_cache;
-        passthru.bdev.required_alignment = base.required_alignment;
-        passthru.bdev.optimal_io_boundary = base.optimal_io_boundary;
-        passthru.bdev.blocklen = base.blocklen;
-        passthru.bdev.blockcnt = base.blockcnt;
-
-        passthru
-            .bdev
-            .__bindgen_anon_1
-            .set_md_interleave(base.__bindgen_anon_1.md_interleave());
-        passthru.bdev.md_len = base.md_len;
-        passthru.bdev.dif_type = base.dif_type;
-        passthru
-            .bdev
-            .__bindgen_anon_1
-            .set_dif_is_head_of_md(base.__bindgen_anon_1.dif_is_head_of_md());
-        passthru.bdev.dif_check_flags = base.dif_check_flags;
-
-        passthru.register()?;
-
-        Ok(passthru.into_device())
+        PassthruRsModule::new_bdev_builder(
+            name.as_c_str(),
+            base.logical_block_size(),
+            base.logical_block_count(),
+        )
+        .with_write_cache_present(base.has_write_cache())
+        .with_buffer_alignment(base.buffer_alignment())
+        .with_optimal_io_boundary(base.optimal_io_boundary())
+        .with_metadata(base.metadata_size(), base.is_metadata_interleaved())
+        .with_dif(
+            base.dif_type(),
+            base.dif_pi_format(),
+            base.is_dif_head_of_metadata(),
+            base.dif_check_flags(),
+        )
+        .build_with_context(PassthruRs { base, desc })
     }
 }
 

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -19,9 +19,9 @@ use spdk_sys::{
     SPDK_BDEV_IO_STATUS_SCSI_ERROR, SPDK_BDEV_IO_STATUS_SUCCESS, spdk_bdev,
     spdk_bdev_destruct_done, spdk_bdev_fn_table, spdk_bdev_io, spdk_bdev_io_complete,
     spdk_bdev_io_get_buf, spdk_bdev_io_get_iovec, spdk_bdev_io_get_thread, spdk_bdev_io_status,
-    spdk_bdev_io_type, spdk_bdev_module, spdk_bdev_register, spdk_bdev_unregister,
-    spdk_get_io_channel, spdk_io_channel, spdk_io_channel_get_ctx, spdk_io_channel_get_thread,
-    spdk_io_device_register, spdk_io_device_unregister,
+    spdk_bdev_io_type, spdk_bdev_register, spdk_bdev_unregister, spdk_get_io_channel,
+    spdk_io_channel, spdk_io_channel_get_ctx, spdk_io_channel_get_thread, spdk_io_device_register,
+    spdk_io_device_unregister,
 };
 use ternary_rs::if_else;
 
@@ -33,6 +33,8 @@ use crate::{
     thread::{self, Thread},
     to_result,
 };
+
+use super::{Module, ModuleInstance, ModuleOps};
 
 /// The status of an I/O operation.
 ///
@@ -488,7 +490,10 @@ where
     /// Creates a new partially initialized BDev instance with the specified name, owning module and
     /// context. Implementors must provide their own constructor function to complete
     /// initialization.
-    pub fn new(name: &CStr, module: *const spdk_bdev_module, ctx: T) -> Box<Self> {
+    pub(crate) fn new<M>(name: &CStr, module: &Module<M>, ctx: T) -> Box<Self>
+    where
+        M: ModuleInstance<M> + Default + ModuleOps + 'static,
+    {
         let mut this = Box::new(Self {
             bdev: unsafe { mem::zeroed() },
             ctx,
@@ -496,7 +501,8 @@ where
 
         this.bdev.ctxt = addr_of_mut!(this.ctx) as *mut c_void;
         this.bdev.name = name.to_owned().into_raw();
-        this.bdev.module = module as *mut _;
+        this.bdev.product_name = M::product_name().as_ptr() as *mut _;
+        this.bdev.module = module.as_ptr() as *mut _;
         this.bdev.fn_table = Self::vtable() as *const _;
 
         this
@@ -510,9 +516,10 @@ where
     /// Creates a new partially initialized BDev instance with the specified name and initializing
     /// the context in-place. Implementors must provider their own constructor function to complete
     /// initialization.
-    pub fn new_in_place<F>(name: &CStr, module: *const spdk_bdev_module, init_fn: F) -> Box<Self>
+    pub(crate) fn new_in_place<F, M>(name: &CStr, module: &Module<M>, init_fn: F) -> Box<Self>
     where
         F: FnOnce(Pin<&mut MaybeUninit<T>>),
+        M: ModuleInstance<M> + Default + ModuleOps + 'static,
     {
         let mut this = Box::new(BDevImpl {
             bdev: unsafe { mem::zeroed() },
@@ -523,7 +530,8 @@ where
 
         this.bdev.ctxt = addr_of_mut!(this.ctx) as *mut c_void;
         this.bdev.name = name.to_owned().into_raw();
-        this.bdev.module = module as *mut _;
+        this.bdev.product_name = M::product_name().as_ptr() as *mut _;
+        this.bdev.module = module.as_ptr() as *mut _;
         this.bdev.fn_table = Self::vtable() as *const _;
 
         unsafe { transmute(this) }

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -3,8 +3,9 @@ use std::{
     future::Future,
     io::{IoSlice, IoSliceMut},
     marker::PhantomData,
-    mem::{self, ManuallyDrop, offset_of, size_of},
+    mem::{self, ManuallyDrop, MaybeUninit, offset_of, size_of, transmute},
     os::raw::{c_int, c_void},
+    pin::Pin,
     ptr::{self, NonNull, addr_of, addr_of_mut, drop_in_place},
     rc::{Rc, Weak},
     slice,
@@ -27,7 +28,7 @@ use ternary_rs::if_else;
 use crate::{
     Result,
     block::{Any, Device, IoType, Owned, OwnedOps},
-    errors::{ECANCELED, EINPROGRESS, EINVAL, ENOMEM, Errno},
+    errors::{ECANCELED, EINPROGRESS, EINVAL, ENOMEM, ENOTSUP, Errno},
     task::{Promise, Promissory},
     thread::{self, Thread},
     to_result,
@@ -109,8 +110,8 @@ impl From<IoStatus> for spdk_bdev_io_status {
 
 /// A trait for implementing the I/O channel operations for a BDev.
 pub trait BDevIoChannelOps: 'static {
-    /// A per-I/O context type accessed through the [`BDevIo::ctx()`] and
-    /// [`BDevIo::ctx_mut()`] methods.
+    /// A per-I/O context type accessed through the [`BDevIo::ctx()`] and [`BDevIo::ctx_mut()`]
+    /// methods.
     ///
     /// [`BDevIo::ctx()`]: method@super::BDevIo::ctx
     /// [`BDevIo::ctx_mut()`]: method@super::BDevIo::ctx_mut
@@ -121,6 +122,16 @@ pub trait BDevIoChannelOps: 'static {
         &mut self,
         io: &mut BDevIo<Self::IoContext>,
     ) -> impl Future<Output = Result<()>>;
+}
+
+/// A stub trait implementation for the `BDevIoChannelOps` trait that does not support any I/O
+/// operations.
+impl BDevIoChannelOps for () {
+    type IoContext = ();
+
+    async fn submit_request(&mut self, _io: &mut BDevIo<Self::IoContext>) -> Result<()> {
+        Err(ENOTSUP)
+    }
 }
 
 /// A BDev I/O channel implementation.
@@ -223,9 +234,8 @@ where
     ///
     /// # Safety
     ///
-    /// This function must only be called from the I/O submission callback to
-    /// initialize a newly submitted I/O request. It initializes the driver
-    /// context to a default value.
+    /// This function must only be called from the I/O submission callback to initialize a newly
+    /// submitted I/O request. It initializes the driver's I/O context to a default value.
     unsafe fn new(io: *mut spdk_bdev_io) -> Self {
         unsafe {
             (*io)
@@ -250,18 +260,18 @@ where
         (unsafe { self.io.as_ref().type_ as spdk_bdev_io_type }).into()
     }
 
-    /// Returns the thread associated with the I/O request. The I/O request must
-    /// be completed on this thread.
+    /// Returns the thread associated with the I/O request. The I/O request must be completed on
+    /// this thread.
     pub fn thread(&self) -> Thread {
-        // SAFETY: The thread associated with the I/O request is guaranteed to
-        // be non-null and valid.
+        // SAFETY: The thread associated with the I/O request is guaranteed to be non-null and
+        // valid.
         unsafe { Thread::from_ptr_unchecked(spdk_bdev_io_get_thread(self.as_ptr())) }
     }
 
     /// Returns the block device associated with the I/O request.
     pub fn device(&self) -> Device<Any> {
-        // SAFETY: The block device associated with the I/O request is
-        // guaranteed to be non-null and valid.
+        // SAFETY: The block device associated with the I/O request is guaranteed to be non-null and
+        // valid.
         unsafe { Device::<Any>::from_ptr_unchecked(self.io.as_ref().bdev) }
     }
 
@@ -304,32 +314,29 @@ where
         unsafe { self.io.as_ref().u.bdev.copy.src_offset_blocks }
     }
 
-    /// Returns a reference to the internal context associated with the I/O
-    /// request.
+    /// Returns a reference to the internal context associated with the I/O request.
     fn internal_ctx(&self) -> &BDevIoCtx<'_, T> {
         unsafe { &*self.io.as_ref().driver_ctx.as_ptr().cast() }
     }
 
-    /// Returns a mutable reference to the internal context associated with the
-    /// I/O request.
+    /// Returns a mutable reference to the internal context associated with the I/O request.
     fn internal_ctx_mut(&mut self) -> &mut BDevIoCtx<'_, T> {
         unsafe { &mut *self.io.as_mut().driver_ctx.as_mut_ptr().cast() }
     }
 
-    /// Returns a reference to the implementation-defined context associated
-    /// with the I/O request.
+    /// Returns a reference to the implementation-defined context associated with the I/O request.
     pub fn ctx(&self) -> &T {
         &self.internal_ctx().inner
     }
 
-    /// Returns a mutable reference to the implementation-defined context
-    /// associated with the I/O request.
+    /// Returns a mutable reference to the implementation-defined context associated with the I/O
+    /// request.
     pub fn ctx_mut(&mut self) -> &mut T {
         &mut self.internal_ctx_mut().inner
     }
 
-    /// Invoked when buffers requested by [`BDevIo<T>::allocate_buffers`] have
-    /// been allocated for the I/O request.
+    /// Invoked when buffers requested by [`BDevIo<T>::allocate_buffers`] have been allocated for
+    /// the I/O request.
     ///
     /// [`BDevIo<T>::allocate_buffers`]: method@BDevIo::allocate_buffers
     unsafe extern "C" fn buffers_allocated(
@@ -351,17 +358,17 @@ where
 
     /// Allocates buffers aligned to the BDev's requirement for the I/O request.
     ///
-    /// Allocation will only occur if no buffers are assigned or the buffers are
-    /// not aligned to the BDev's requirement. If the buffers are not aligned,
-    /// this call will cause a copy from the current buffers to a bounce buffer
-    /// on write or a copy from the bounce buffer to the current buffers on read.
+    /// Allocation will only occur if no buffers are assigned or the buffers are not aligned to the
+    /// BDev's requirement. If the buffers are not aligned, this call will cause a copy from the
+    /// current buffers to a bounce buffer on write or a copy from the bounce buffer to the current
+    /// buffers on read.
     ///
-    /// If no buffers are currently assigned to this I/O request, the `length`
-    /// parameter specifies the size of the buffers to allocate in bytes. This
-    /// value must be no larger than `SPDK_BDEV_LARGE_BUF_MAX_SIZE`.
+    /// If no buffers are currently assigned to this I/O request, the `length` parameter specifies
+    /// the size of the buffers to allocate in bytes. This value must be no larger than
+    /// `SPDK_BDEV_LARGE_BUF_MAX_SIZE`.
     ///
-    /// Any buffers allocated by this method will automatically be freed on
-    /// completion of this I/O request.
+    /// Any buffers allocated by this method will automatically be freed on completion of this I/O
+    /// request.
     pub async fn allocate_buffers<'a>(&'a mut self, length: u64) -> Result<()> {
         Promise::with_context(PhantomData::<&'a mut Self>)
             .request(move |p| {
@@ -422,9 +429,8 @@ pub trait BDevOps: Send + Sync + 'static {
     ///
     /// # Notes
     ///
-    /// The default implementation returns a per-thread I/O channel for the
-    /// BDev. Implementations may override this method to provide different
-    /// behavior.
+    /// The default implementation returns a per-thread I/O channel for the BDev. Implementations
+    /// may override this method to provide different behavior.
     fn get_io_channel(&self) -> Result<BDevIoChannel<Self::IoChannel>> {
         unsafe { spdk_get_io_channel(self as *const _ as *mut _).try_into() }
     }
@@ -435,6 +441,27 @@ pub trait BDevOps: Send + Sync + 'static {
     /// Returns the size in bytes of the per-I/O context.
     fn get_io_context_size() -> usize {
         size_of::<BDevIoCtx<<<Self as BDevOps>::IoChannel as BDevIoChannelOps>::IoContext>>()
+    }
+}
+
+/// A stub trait implementation for the `BDevOps` trait that enables in-place initialization of a
+/// BDev's context
+impl<T> BDevOps for MaybeUninit<T>
+where
+    T: BDevOps,
+{
+    type IoChannel = ();
+
+    async fn destruct(&mut self) -> Result<()> {
+        unimplemented!("destruct called on uninitialized value");
+    }
+
+    fn io_type_supported(&self, _io_type: IoType) -> bool {
+        unimplemented!("io_type_supported called on uninitialized value");
+    }
+
+    fn new_io_channel(&mut self) -> Result<Self::IoChannel> {
+        unimplemented!("new_io_channel called on uninitialized value");
     }
 }
 
@@ -456,11 +483,11 @@ unsafe impl<T> Sync for BDevImpl<T> where T: BDevOps + Sync + ?Sized {}
 
 impl<T> BDevImpl<T>
 where
-    T: BDevOps,
+    T: BDevOps + Unpin,
 {
-    /// Creates a new partially initialized BDev instance with the specified
-    /// name, owning module and context. Implementors must provider their own
-    /// constructor function to complete initialization.
+    /// Creates a new partially initialized BDev instance with the specified name, owning module and
+    /// context. Implementors must provide their own constructor function to complete
+    /// initialization.
     pub fn new(name: &CStr, module: *const spdk_bdev_module, ctx: T) -> Box<Self> {
         let mut this = Box::new(Self {
             bdev: unsafe { mem::zeroed() },
@@ -474,20 +501,46 @@ where
 
         this
     }
+}
+
+impl<T> BDevImpl<T>
+where
+    T: BDevOps,
+{
+    /// Creates a new partially initialized BDev instance with the specified name and initializing
+    /// the context in-place. Implementors must provider their own constructor function to complete
+    /// initialization.
+    pub fn new_in_place<F>(name: &CStr, module: *const spdk_bdev_module, init_fn: F) -> Box<Self>
+    where
+        F: FnOnce(Pin<&mut MaybeUninit<T>>),
+    {
+        let mut this = Box::new(BDevImpl {
+            bdev: unsafe { mem::zeroed() },
+            ctx: MaybeUninit::<T>::uninit(),
+        });
+
+        init_fn(unsafe { Pin::new_unchecked(&mut this.ctx) });
+
+        this.bdev.ctxt = addr_of_mut!(this.ctx) as *mut c_void;
+        this.bdev.name = name.to_owned().into_raw();
+        this.bdev.module = module as *mut _;
+        this.bdev.fn_table = Self::vtable() as *const _;
+
+        unsafe { transmute(this) }
+    }
 
     /// Converts a raw `spdk_bdev` pointer to a reference to the BDevImpl.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that the `spdk_bdev` pointer is valid and points
-    /// to a `BDevImpl<T>` instance. This function does not perform any
-    /// validation on the pointer.
+    /// The caller must ensure that the `spdk_bdev` pointer is valid and points to a `BDevImpl<T>`
+    /// instance. This function does not perform any validation on the pointer.
     pub unsafe fn from_raw(bdev: *mut spdk_bdev) -> &'static BDevImpl<T> {
         unsafe { &*bdev.byte_sub(offset_of!(BDevImpl<T>, ctx)).cast() }
     }
 
-    /// Registers the BDev with the SPDK subsystem. This function must be called
-    /// from the SPDK application thread.
+    /// Registers the BDev with the SPDK subsystem. This function must be called from the SPDK
+    /// application thread.
     pub fn register(&mut self) -> Result<()> {
         unsafe {
             spdk_io_device_register(
@@ -507,8 +560,8 @@ where
         Ok(())
     }
 
-    /// Unregisters the BDev from the SPDK subsystem. This function must be
-    /// called from the SPDK application thread.
+    /// Unregisters the BDev from the SPDK subsystem. This function must be called from the SPDK
+    /// application thread.
     pub async fn unregister(self: Box<Self>) -> Result<()> {
         let bdev_ptr = self.into_bdev_ptr();
 
@@ -525,16 +578,15 @@ where
             .await
     }
 
-    /// Consumes the boxed instance and returns a [`Device<Owned>`] instance
-    /// that owns the BDev.
+    /// Consumes the boxed instance and returns a [`Device<Owned>`] instance that owns the BDev.
     pub fn into_device(self: Box<Self>) -> Device<Owned> {
         Device::new(OwnedImpl::new(self)).into_owned().unwrap()
     }
 
     /// Consumes the boxed BDev instance and returns a raw pointer to the BDev.
     ///
-    /// After calling this function, the caller is responsible for managing the
-    /// memory previously owned by the boxed BDev instance.
+    /// After calling this function, the caller is responsible for managing the memory previously
+    /// owned by the boxed BDev instance.
     fn into_bdev_ptr(self: Box<Self>) -> *mut spdk_bdev {
         addr_of_mut!(Box::leak(self).bdev)
     }
@@ -681,9 +733,9 @@ impl<T: BDevOps> OwnedOps for OwnedImpl<T> {
     }
 
     async fn destroy(self) -> Result<()> {
-        // The BDev implementation's `destruct` method is invoked by the called
-        // to unregister the device and will take care of dropping the box. We
-        // avoid dropping the box here to prevent double-free.
+        // The BDev implementation's `destruct` method is invoked by the call to unregister the
+        // device and will take care of dropping the box. We avoid dropping the box here to prevent
+        // double-free.
         let bdev = ManuallyDrop::new(self);
 
         Promise::new()

--- a/spdk/src/bdev/bdev.rs
+++ b/spdk/src/bdev/bdev.rs
@@ -19,9 +19,13 @@ use spdk_sys::{
     SPDK_BDEV_IO_STATUS_SCSI_ERROR, SPDK_BDEV_IO_STATUS_SUCCESS, spdk_bdev,
     spdk_bdev_destruct_done, spdk_bdev_fn_table, spdk_bdev_io, spdk_bdev_io_complete,
     spdk_bdev_io_get_buf, spdk_bdev_io_get_iovec, spdk_bdev_io_get_thread, spdk_bdev_io_status,
-    spdk_bdev_io_type, spdk_bdev_register, spdk_bdev_unregister, spdk_get_io_channel,
-    spdk_io_channel, spdk_io_channel_get_ctx, spdk_io_channel_get_thread, spdk_io_device_register,
-    spdk_io_device_unregister,
+    spdk_bdev_io_type, spdk_bdev_register, spdk_bdev_unregister,
+    spdk_dif_pi_format::{
+        self, SPDK_DIF_PI_FORMAT_16, SPDK_DIF_PI_FORMAT_32, SPDK_DIF_PI_FORMAT_64,
+    },
+    spdk_dif_type::{self, SPDK_DIF_DISABLE},
+    spdk_get_io_channel, spdk_io_channel, spdk_io_channel_get_ctx, spdk_io_channel_get_thread,
+    spdk_io_device_register, spdk_io_device_unregister,
 };
 use ternary_rs::if_else;
 
@@ -34,7 +38,7 @@ use crate::{
     to_result,
 };
 
-use super::{Module, ModuleInstance, ModuleOps};
+use super::{Module, ModuleOps};
 
 /// The status of an I/O operation.
 ///
@@ -482,61 +486,10 @@ where
 unsafe impl<T> Send for BDevImpl<T> where T: BDevOps + Send + ?Sized {}
 
 unsafe impl<T> Sync for BDevImpl<T> where T: BDevOps + Sync + ?Sized {}
-
-impl<T> BDevImpl<T>
-where
-    T: BDevOps + Unpin,
-{
-    /// Creates a new partially initialized BDev instance with the specified name, owning module and
-    /// context. Implementors must provide their own constructor function to complete
-    /// initialization.
-    pub(crate) fn new<M>(name: &CStr, module: &Module<M>, ctx: T) -> Box<Self>
-    where
-        M: ModuleInstance<M> + Default + ModuleOps + 'static,
-    {
-        let mut this = Box::new(Self {
-            bdev: unsafe { mem::zeroed() },
-            ctx,
-        });
-
-        this.bdev.ctxt = addr_of_mut!(this.ctx) as *mut c_void;
-        this.bdev.name = name.to_owned().into_raw();
-        this.bdev.product_name = M::product_name().as_ptr() as *mut _;
-        this.bdev.module = module.as_ptr() as *mut _;
-        this.bdev.fn_table = Self::vtable() as *const _;
-
-        this
-    }
-}
-
 impl<T> BDevImpl<T>
 where
     T: BDevOps,
 {
-    /// Creates a new partially initialized BDev instance with the specified name and initializing
-    /// the context in-place. Implementors must provider their own constructor function to complete
-    /// initialization.
-    pub(crate) fn new_in_place<F, M>(name: &CStr, module: &Module<M>, init_fn: F) -> Box<Self>
-    where
-        F: FnOnce(Pin<&mut MaybeUninit<T>>),
-        M: ModuleInstance<M> + Default + ModuleOps + 'static,
-    {
-        let mut this = Box::new(BDevImpl {
-            bdev: unsafe { mem::zeroed() },
-            ctx: MaybeUninit::<T>::uninit(),
-        });
-
-        init_fn(unsafe { Pin::new_unchecked(&mut this.ctx) });
-
-        this.bdev.ctxt = addr_of_mut!(this.ctx) as *mut c_void;
-        this.bdev.name = name.to_owned().into_raw();
-        this.bdev.product_name = M::product_name().as_ptr() as *mut _;
-        this.bdev.module = module.as_ptr() as *mut _;
-        this.bdev.fn_table = Self::vtable() as *const _;
-
-        unsafe { transmute(this) }
-    }
-
     /// Converts a raw `spdk_bdev` pointer to a reference to the BDevImpl.
     ///
     /// # Safety
@@ -720,6 +673,329 @@ where
 {
     fn drop(&mut self) {
         unsafe { drop(CString::from_raw(self.bdev.name)) }
+    }
+}
+
+/// A builder used to create a new instance of a `BDev`.
+///
+/// Create a new instance by calling the [`new_bdev_builder()`] method of the [`Module`] managing
+/// the `BDev` type.
+///
+/// [`new_bdev_builder()`]: super::ModuleOps::new_bdev_builder
+pub struct BDevBuilder<'a, C, M>
+where
+    C: BDevOps,
+    M: ModuleOps,
+{
+    module: &'a Module<M>,
+    name: &'a CStr,
+    block_size: u32,
+    num_blocks: u64,
+    write_cache_present: bool,
+    physical_block_size: u32,
+    buffer_alignment: u8,
+    optimal_io_boundary: u32,
+    metadata_size: Option<u32>,
+    is_metadata_interleaved: bool,
+    dif_type: spdk_dif_type,
+    dif_pi_format: Option<spdk_dif_pi_format>,
+    dif_is_head_of_md: bool,
+    dif_check_flags: u32,
+    numa_id: Option<i32>,
+
+    _phantom: PhantomData<C>,
+}
+
+impl<'a, C, M> BDevBuilder<'a, C, M>
+where
+    C: BDevOps,
+    M: ModuleOps,
+{
+    /// Creates a new [`BDevBuilder`] instance.
+    pub(crate) fn new(
+        module: &'a Module<M>,
+        name: &'a CStr,
+        block_size: u32,
+        num_blocks: u64,
+    ) -> Self {
+        Self {
+            module,
+            name,
+            block_size,
+            num_blocks,
+            write_cache_present: false,
+            physical_block_size: 0,
+            buffer_alignment: 0,
+            optimal_io_boundary: 0,
+            metadata_size: None,
+            is_metadata_interleaved: false,
+            dif_type: SPDK_DIF_DISABLE,
+            dif_is_head_of_md: false,
+            dif_pi_format: None,
+            dif_check_flags: 0,
+            numa_id: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Initializes the `spdk_bdev` structure of the `BDev` being built.
+    ///
+    /// # Safety
+    ///
+    /// This function assumes the memory referenced by the `bdev` argument has been initialized to
+    /// zeroes. Failure to do so results in **undefined behavior**.
+    ///
+    /// The `ctx` argument is a raw pointer to the new `BDev`'s context. It may be uninitialized at
+    /// this point, so dereferecing it results in **undefined behavior**. This method simply stores
+    /// the pointer value in the `spdk_bdev`'s `ctxt` field. The caller must ensure that the context
+    /// is properly initialized before this field can be deferenced.
+    unsafe fn init_bdev(&self, bdev: &mut spdk_bdev, ctx: *mut c_void) {
+        bdev.ctxt = ctx;
+        bdev.name = self.name.to_owned().into_raw();
+        bdev.product_name = M::product_name().as_ptr() as *mut _;
+        bdev.module = self.module.as_ptr() as *mut _;
+        bdev.fn_table = BDevImpl::<C>::vtable() as *const _;
+        bdev.write_cache = self.write_cache_present as i32;
+        bdev.blocklen = self.block_size;
+        bdev.blockcnt = self.num_blocks;
+        bdev.phys_blocklen = self.physical_block_size;
+        bdev.required_alignment = self.buffer_alignment;
+        bdev.optimal_io_boundary = self.optimal_io_boundary;
+        bdev.md_len = self.metadata_size.unwrap_or(0);
+        bdev.__bindgen_anon_1
+            .set_md_interleave(self.is_metadata_interleaved as u32);
+        bdev.dif_type = self.dif_type;
+        bdev.__bindgen_anon_1
+            .set_dif_is_head_of_md(self.dif_is_head_of_md as u32);
+        bdev.dif_pi_format = self.dif_pi_format.unwrap_or(SPDK_DIF_PI_FORMAT_16);
+        bdev.dif_check_flags = self.dif_check_flags;
+
+        if let Some(numa_id) = self.numa_id {
+            bdev.numa.set_id(numa_id);
+            bdev.numa.set_id_valid(true as u32);
+        }
+    }
+
+    /// Set whether the new `BDev` has a write cache.
+    pub fn with_write_cache_present(mut self, has_write_cache: bool) -> Self {
+        self.write_cache_present = has_write_cache;
+        self
+    }
+
+    /// Set the new `BDev`'s physical block size.
+    ///
+    /// If the physical block size is not explcitly set, it is assumed to be the same size of a
+    /// logical block.
+    pub fn with_physical_block_size(mut self, size: u32) -> Self {
+        self.physical_block_size = size;
+        self
+    }
+
+    /// Set the new `BDev`'s minimum buffer alignment.
+    ///
+    /// The alignment must be a non-zero power of 2. If not explicitly specified, byte alignment is
+    /// assumed.
+    ///
+    /// # Panics
+    ///
+    /// The value must be a non-zero power of 2 otherwise this function panics.
+    pub fn with_buffer_alignment(mut self, alignment: usize) -> Self {
+        assert!(
+            alignment.is_power_of_two(),
+            "buffer alignment must be a power of two"
+        );
+        self.buffer_alignment = alignment.checked_ilog2().expect("not zero") as u8;
+        self
+    }
+
+    /// Set the new `BDev`'s optimal I/O boundary in number of blocks.
+    ///
+    /// If not explicitly specified, no boundary is assumed.
+    pub fn with_optimal_io_boundary(mut self, boundary: u32) -> Self {
+        self.optimal_io_boundary = boundary;
+        self
+    }
+
+    /// Set the new `BDev`'s metadata parameters.
+    ///
+    /// If not explicitly specified, it is assumed the new `BDev` does not support metadata or
+    /// supports only the [Data Integrity Field (DIF)] as specified by the [`Self::with_dif()`]
+    /// method.
+    ///
+    /// # Parameters
+    ///
+    /// - `size`: The size of the metadata in bytes. A value of zero indicates no metadata is supported.
+    /// - `interleaved`: Specifies whether the metadata is interleaved with or separate from the
+    ///   block data.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if DIF was enabled and the specified metadata size is smaller than the
+    /// required number of DIF bytes.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn with_metadata(mut self, size: u32, interleaved: bool) -> Self {
+        let min_md_size = match self.dif_pi_format {
+            Some(SPDK_DIF_PI_FORMAT_16) => 8,
+            Some(SPDK_DIF_PI_FORMAT_32) | Some(SPDK_DIF_PI_FORMAT_64) => 16,
+            None => 0,
+        };
+
+        assert!(
+            size >= min_md_size,
+            "the metadata size of {size} bytes is less than the {min_md_size} bytes required by the DIF configuration"
+        );
+
+        self.metadata_size = Some(size);
+        self.is_metadata_interleaved = interleaved;
+        self
+    }
+
+    /// Set the new `BDev`'s [Data Integrity Field (DIF)] parameters.
+    ///
+    /// If the metadata size has not been set, this method sets the metadata size to the number of
+    /// bytes required by the DIF configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `type`: A value from the [`spdk_dif_type`] enum specifying the DIF type. If
+    ///   `SPDK_DIF_DISABLE`, DIF is disabled for this block device and the remaining parameters are
+    ///   ignored.
+    /// - `pi_format`: An optional value from the [`spdk_dif_pi_format`] enum specifying the
+    ///   protection information format. This parameter is required to be specified as
+    ///   `Some(pi_format)` if DIF is not disabled.
+    /// - `is_head_of_md`: Specifies whether the DIF is set in the new `BDev`'s first or last 8|16
+    ///   bytes of metadata.
+    /// - `check_flags`: The bitmap of enabled DIF checks.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the metadata size has already been specified and is less than the
+    /// number of bytes required by the DIF configuration.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    /// [`spdk_dif_type`]: spdk_sys::spdk_dif_type
+    /// [`spdk_dif_pi_format`]: spdk_sys::spdk_dif_pi_format
+    pub fn with_dif(
+        mut self,
+        r#type: spdk_dif_type,
+        pi_format: Option<spdk_dif_pi_format>,
+        is_head_of_md: bool,
+        check_flags: u32,
+    ) -> Self {
+        assert!(
+            self.dif_type == SPDK_DIF_DISABLE,
+            "DIF parameters can only be set once"
+        );
+
+        self.dif_type = r#type;
+
+        if self.dif_type != SPDK_DIF_DISABLE {
+            let min_md_size = match pi_format {
+                Some(SPDK_DIF_PI_FORMAT_16) => 8,
+                Some(SPDK_DIF_PI_FORMAT_32) | Some(SPDK_DIF_PI_FORMAT_64) => 16,
+                None => panic!("PI format must be specified if DIF is enabled"),
+            };
+
+            match self.metadata_size {
+                None => self.metadata_size = Some(min_md_size),
+                Some(size) => {
+                    assert!(
+                        size >= min_md_size,
+                        "the metadata size of {size} bytes is less than the {min_md_size} bytes required by the DIF configuration"
+                    );
+                }
+            }
+
+            self.dif_pi_format = pi_format;
+            self.dif_is_head_of_md = is_head_of_md;
+            self.dif_check_flags = check_flags
+        }
+        self
+    }
+
+    /// Set the new `BDev`'s NUMA node ID.
+    ///
+    /// The specified value may be `None` if the NUMA node ID is not known.
+    pub fn with_numa_id(mut self, numa_id: Option<i32>) -> Self {
+        self.numa_id = numa_id;
+        self
+    }
+}
+
+impl<'a, C, M> BDevBuilder<'a, C, M>
+where
+    C: BDevOps + Default + Unpin + 'static,
+    M: ModuleOps,
+{
+    /// Builds and registers a new `BDev` instance with the context initialized to default values.
+    pub fn build(self) -> Result<Device<Owned>> {
+        let mut bdev = Box::new(BDevImpl {
+            bdev: unsafe { mem::zeroed() },
+            ctx: C::default(),
+        });
+
+        // SAFETY: The `BDev`'s `spdk_bdev` struct has been zeroed and context initialized at this
+        // point.
+        unsafe { self.init_bdev(&mut bdev.bdev, addr_of_mut!(bdev.ctx) as *mut _) };
+
+        bdev.register()?;
+
+        Ok(bdev.into_device())
+    }
+}
+
+impl<'a, C, M> BDevBuilder<'a, C, M>
+where
+    C: BDevOps + Unpin + 'static,
+    M: ModuleOps,
+{
+    /// Builds and registers a new `BDev` instance with the specified context.
+    pub fn build_with_context(self, ctx: C) -> Result<Device<Owned>> {
+        let mut bdev = Box::new(BDevImpl {
+            bdev: unsafe { mem::zeroed() },
+            ctx,
+        });
+
+        // SAFETY: The `BDev`'s `spdk_bdev` struct has been zeroed and context initialized at this
+        // point.
+        unsafe { self.init_bdev(&mut bdev.bdev, addr_of_mut!(bdev.ctx) as *mut _) };
+
+        bdev.register()?;
+
+        Ok(bdev.into_device())
+    }
+}
+
+impl<'a, C, M> BDevBuilder<'a, C, M>
+where
+    C: BDevOps + 'static,
+    M: ModuleOps,
+{
+    /// Builds and registers a new `BDev` instance, initializing the context in-place using the
+    /// specified initialization function.
+    pub fn build_with_context_in_place<I>(self, init_fn: I) -> Result<Device<Owned>>
+    where
+        I: FnOnce(Pin<&mut MaybeUninit<C>>),
+    {
+        let mut bdev = Box::new(BDevImpl {
+            bdev: unsafe { mem::zeroed() },
+            ctx: MaybeUninit::<C>::uninit(),
+        });
+
+        // SAFETY: The `BDev`'s `spdk_bdev` struct has been zeroed. It's context will be initialized
+        // on the line following this call and before the `BDev` is available globally.
+        unsafe { self.init_bdev(&mut bdev.bdev, addr_of_mut!(bdev.ctx) as *mut _) };
+
+        init_fn(unsafe { Pin::new_unchecked(&mut bdev.ctx) });
+
+        // SAFETY: The `BDev` is fully initialized at this point.
+        let mut bdev =
+            unsafe { transmute::<Box<BDevImpl<MaybeUninit<C>>>, Box<BDevImpl<C>>>(bdev) };
+
+        bdev.register()?;
+
+        Ok(bdev.into_device())
     }
 }
 

--- a/spdk/src/bdev/mod.rs
+++ b/spdk/src/bdev/mod.rs
@@ -17,7 +17,7 @@ mod bdev;
 mod module;
 
 #[cfg(feature = "bdev-module")]
-pub use bdev::{BDevImpl, BDevIo, BDevIoChannel, BDevIoChannelOps, BDevOps, IoStatus};
+pub use bdev::{BDevBuilder, BDevImpl, BDevIo, BDevIoChannel, BDevIoChannelOps, BDevOps, IoStatus};
 
 #[cfg(feature = "bdev-module")]
 pub use module::{Module, ModuleInstance, ModuleOps};

--- a/spdk/src/bdev/module.rs
+++ b/spdk/src/bdev/module.rs
@@ -12,8 +12,24 @@ use crate::{
 
 use super::{BDevImpl, BDevOps};
 
+/// A trait implemented by the [`module`] attribute macro to provide access to the singleton
+/// [`Module`] instance.
+///
+/// [`module`]: macro@crate::module
+/// [`Module`]: struct@super::Module
+pub trait ModuleInstance<T>
+where
+    T: Default + ModuleOps + 'static,
+{
+    /// Returns a reference to the singleton instance of the module.
+    fn instance() -> &'static Module<T>;
+
+    /// Returns the product name for BDevs created by this module.
+    fn product_name() -> &'static CStr;
+}
+
 /// A trait defining BDev module operations.
-pub trait ModuleOps {
+pub trait ModuleOps: ModuleInstance<Self> + Default + 'static {
     /// The BDev type implemented by the module.
     type BDev: BDevOps;
 
@@ -54,28 +70,15 @@ pub trait ModuleOps {
     fn examine_disk(&self, _bdev: Device<Any>) -> impl std::future::Future<Output = ()> {
         async {}
     }
-}
-
-/// A trait implemented by the [`module`] attribute macro to provide access to the singleton
-/// [`Module`] instance.
-///
-/// [`module`]: macro@crate::module
-/// [`Module`]: struct@super::Module
-pub trait ModuleInstance<T>
-where
-    T: Default + ModuleOps + 'static,
-{
-    /// Returns a reference to the singleton instance of the module.
-    fn instance() -> &'static T;
-
-    /// Returns a raw pointer to the singleton instance of the module.
-    fn module() -> *const spdk_bdev_module;
 
     /// Creates a new partially initialized BDev instance with the specified name and context.
     /// Implementors must provider their own constructor function to complete initialization.
     fn new_bdev<C>(name: &CStr, ctx: C) -> Box<BDevImpl<C>>
     where
-        C: BDevOps + Unpin;
+        C: BDevOps + Unpin,
+    {
+        BDevImpl::new(name, Self::instance(), ctx)
+    }
 
     /// Creates a new partially initialized BDev instance with the specified name and initializing
     /// the context in-place. Implementors must provider their own constructor function to complete
@@ -83,12 +86,15 @@ where
     fn new_bdev_in_place<C, I>(name: &CStr, init_fn: I) -> Box<BDevImpl<C>>
     where
         C: BDevOps,
-        I: FnOnce(Pin<&mut MaybeUninit<C>>);
+        I: FnOnce(Pin<&mut MaybeUninit<C>>),
+    {
+        BDevImpl::new_in_place(name, Self::instance(), init_fn)
+    }
 }
 
 /// A BDev module implementation created by the [`module`] attribute macro.
 ///
-/// The type parameter `T` is the module instance type.
+/// The type parameter `T` is the module context type.
 ///
 /// [`module`]: macro@crate::module
 #[derive(Debug)]
@@ -96,8 +102,8 @@ pub struct Module<T>
 where
     T: ModuleInstance<T> + Default + ModuleOps + 'static,
 {
-    pub module: spdk_bdev_module,
-    pub instance: T,
+    module: spdk_bdev_module,
+    ctx: T,
 }
 
 unsafe impl<T> Send for Module<T> where T: ModuleInstance<T> + Default + ModuleOps + Send + 'static {}
@@ -132,7 +138,7 @@ where
 
         Self {
             module,
-            instance: Default::default(),
+            ctx: Default::default(),
         }
     }
 
@@ -146,13 +152,23 @@ where
         unsafe { spdk_bdev_module_list_add(&self.module as *const _ as *mut _) };
     }
 
+    /// Returns a pointer to the underlying `spdk_bdev_module` structure.
+    pub(crate) fn as_ptr(&self) -> *const ::spdk_sys::spdk_bdev_module {
+        &self.module as *const _
+    }
+
+    /// Returns a reference to the module context.
+    pub fn ctx(&self) -> &T {
+        &self.ctx
+    }
+
     /// Initializes the module.
     unsafe extern "C" fn init() -> i32 {
         thread::spawn_local(async {
-            T::instance().init().await;
+            T::instance().ctx.init().await;
 
             unsafe {
-                spdk_bdev_module_init_done(T::module() as *mut _);
+                spdk_bdev_module_init_done(T::instance().as_ptr() as *mut _);
             }
         });
 
@@ -162,7 +178,7 @@ where
     /// Finalizes the module.
     unsafe extern "C" fn fini() {
         thread::spawn_local(async {
-            T::instance().fini().await;
+            T::instance().ctx.fini().await;
 
             unsafe {
                 spdk_bdev_module_fini_done();
@@ -172,7 +188,7 @@ where
 
     /// Returns the size in bytes of the per-I/O context.
     unsafe extern "C" fn get_io_context_size() -> i32 {
-        T::instance().get_io_context_size() as i32
+        T::instance().ctx.get_io_context_size() as i32
     }
 
     /// Examines the specified block device to determine whether it should be claimed by a Virtual
@@ -185,9 +201,9 @@ where
     ///
     /// The default implementation claims no devices.
     unsafe extern "C" fn examine_config(bdev: *mut spdk_bdev) {
-        T::instance().examine_config(bdev.into());
+        T::instance().ctx.examine_config(bdev.into());
 
-        unsafe { spdk_bdev_module_examine_done(T::module() as *mut _) }
+        unsafe { spdk_bdev_module_examine_done(T::instance().as_ptr() as *mut _) }
     }
 
     /// Examines the specified block device to determine whether it should be claimed by a Virtual
@@ -203,9 +219,9 @@ where
         let bdev = bdev.into();
 
         thread::spawn_local(async move {
-            T::instance().examine_disk(bdev).await;
+            T::instance().ctx.examine_disk(bdev).await;
 
-            unsafe { spdk_bdev_module_examine_done(T::module() as *mut _) }
+            unsafe { spdk_bdev_module_examine_done(T::instance().as_ptr() as *mut _) }
         });
     }
 }

--- a/spdk/src/bdev/module.rs
+++ b/spdk/src/bdev/module.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, fmt::Debug, future::Future, mem::MaybeUninit, pin::Pin};
+use std::{ffi::CStr, fmt::Debug, future::Future};
 
 use spdk_sys::{
     spdk_bdev, spdk_bdev_module, spdk_bdev_module_examine_done, spdk_bdev_module_fini_done,
@@ -10,7 +10,7 @@ use crate::{
     thread::{self},
 };
 
-use super::{BDevImpl, BDevOps};
+use super::{BDevBuilder, BDevOps};
 
 /// A trait implemented by the [`module`] attribute macro to provide access to the singleton
 /// [`Module`] instance.
@@ -71,24 +71,13 @@ pub trait ModuleOps: ModuleInstance<Self> + Default + 'static {
         async {}
     }
 
-    /// Creates a new partially initialized BDev instance with the specified name and context.
-    /// Implementors must provider their own constructor function to complete initialization.
-    fn new_bdev<C>(name: &CStr, ctx: C) -> Box<BDevImpl<C>>
-    where
-        C: BDevOps + Unpin,
-    {
-        BDevImpl::new(name, Self::instance(), ctx)
-    }
-
-    /// Creates a new partially initialized BDev instance with the specified name and initializing
-    /// the context in-place. Implementors must provider their own constructor function to complete
-    /// initialization.
-    fn new_bdev_in_place<C, I>(name: &CStr, init_fn: I) -> Box<BDevImpl<C>>
-    where
-        C: BDevOps,
-        I: FnOnce(Pin<&mut MaybeUninit<C>>),
-    {
-        BDevImpl::new_in_place(name, Self::instance(), init_fn)
+    /// Creates a new [`BDevBuilder`] to build a new `BDev` instance managed by this module.
+    fn new_bdev_builder<'a>(
+        name: &'a CStr,
+        block_size: u32,
+        num_blocks: u64,
+    ) -> BDevBuilder<'a, Self::BDev, Self> {
+        BDevBuilder::new(Self::instance(), name, block_size, num_blocks)
     }
 }
 

--- a/spdk/src/bdev/module.rs
+++ b/spdk/src/bdev/module.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, fmt::Debug, future::Future};
+use std::{ffi::CStr, fmt::Debug, future::Future, mem::MaybeUninit, pin::Pin};
 
 use spdk_sys::{
     spdk_bdev, spdk_bdev_module, spdk_bdev_module_examine_done, spdk_bdev_module_fini_done,
@@ -32,25 +32,23 @@ pub trait ModuleOps {
         Self::BDev::get_io_context_size()
     }
 
-    /// Examines the specified block device to determine whether it should be
-    /// claimed by a Virtual BDev implemented by this module.
+    /// Examines the specified block device to determine whether it should be claimed by a Virtual
+    /// BDev implemented by this module.
     ///
-    /// This method provides the first notification to a Virtual BDev module to
-    /// examine newly-added block devices and automatically create their own
-    /// Virtual BDevs. However, no I/O to the device can be submitted in this
-    /// method. The decision whether to claim the BDev must be made
+    /// This method provides the first notification to a Virtual BDev module to examine newly-added
+    /// block devices and automatically create their own Virtual BDevs. However, no I/O to the
+    /// device can be submitted in this method. The decision whether to claim the BDev must be made
     /// synchronously.
     ///
     /// The default implementation claims no devices.
     fn examine_config(&self, _bdev: Device<Any>) {}
 
-    /// Examines the specified block device to determine whether it should be
-    /// claimed by a Virtual BDev implemented by this module.
+    /// Examines the specified block device to determine whether it should be claimed by a Virtual
+    /// BDev implemented by this module.
     ///
-    /// This method provides the second notification to a Virtual BDev module to
-    /// examine newly-added block devices and automatically create their own
-    /// Virtual BDevs. I/O may be submitted to the device in this method and the
-    /// decision whether to claim can be made asynchronously.
+    /// This method provides the second notification to a Virtual BDev module to examine newly-added
+    /// block devices and automatically create their own Virtual BDevs. I/O may be submitted to the
+    /// device in this method and the decision whether to claim can be made asynchronously.
     ///
     /// The default implementation claims no devices.
     fn examine_disk(&self, _bdev: Device<Any>) -> impl std::future::Future<Output = ()> {
@@ -58,8 +56,8 @@ pub trait ModuleOps {
     }
 }
 
-/// A trait implemented by the [`module`] attribute macro to provide access to
-/// the singleton [`Module`] instance.
+/// A trait implemented by the [`module`] attribute macro to provide access to the singleton
+/// [`Module`] instance.
 ///
 /// [`module`]: macro@crate::module
 /// [`Module`]: struct@super::Module
@@ -73,12 +71,19 @@ where
     /// Returns a raw pointer to the singleton instance of the module.
     fn module() -> *const spdk_bdev_module;
 
-    /// Creates a new partially initialized BDev instance with the specified
-    /// name and context. Implementors must provider their own constructor
-    /// function to complete initialization.
-    fn new_bdev<B>(name: &CStr, ctx: B) -> Box<BDevImpl<B>>
+    /// Creates a new partially initialized BDev instance with the specified name and context.
+    /// Implementors must provider their own constructor function to complete initialization.
+    fn new_bdev<C>(name: &CStr, ctx: C) -> Box<BDevImpl<C>>
     where
-        B: BDevOps;
+        C: BDevOps + Unpin;
+
+    /// Creates a new partially initialized BDev instance with the specified name and initializing
+    /// the context in-place. Implementors must provider their own constructor function to complete
+    /// initialization.
+    fn new_bdev_in_place<C, I>(name: &CStr, init_fn: I) -> Box<BDevImpl<C>>
+    where
+        C: BDevOps,
+        I: FnOnce(Pin<&mut MaybeUninit<C>>);
 }
 
 /// A BDev module implementation created by the [`module`] attribute macro.
@@ -105,8 +110,8 @@ where
 {
     /// Creates a new BDev module instance with the specified name.
     ///
-    /// This method is used by the [`module`] attribute macro to create the
-    /// singleton module instance. It must not be called directly.
+    /// This method is used by the [`module`] attribute macro to create the singleton module
+    /// instance. It must not be called directly.
     ///
     /// [`module`]: macro@crate::module
     pub fn new(name: &'static CStr) -> Self {
@@ -133,8 +138,8 @@ where
 
     /// Registers the module with the SPDK BDev module list.
     ///
-    /// This method is used by the [`module`] attribute macro to register the
-    /// singleton module instance. It must not be called directly.
+    /// This method is used by the [`module`] attribute macro to register the singleton module
+    /// instance. It must not be called directly.
     ///
     /// [`module`]: macro@crate::module
     pub fn register(&self) {
@@ -170,14 +175,13 @@ where
         T::instance().get_io_context_size() as i32
     }
 
-    /// Examines the specified block device to determine whether it should be
-    /// claimed by a Virtual BDev implemented by this module.
+    /// Examines the specified block device to determine whether it should be claimed by a Virtual
+    /// BDev implemented by this module.
     ///
-    /// This function provides the first notification to a Virtual BDev module
-    /// to examine newly-added block devices and automatically create their own
-    /// Virtual BDevs. However, no I/O to the device can be submitted in this
-    /// function. The decision whether to claim the BDev must be made
-    /// synchronously.
+    /// This function provides the first notification to a Virtual BDev module to examine
+    /// newly-added block devices and automatically create their own Virtual BDevs. However, no I/O
+    /// to the device can be submitted in this function. The decision whether to claim the BDev must
+    /// be made synchronously.
     ///
     /// The default implementation claims no devices.
     unsafe extern "C" fn examine_config(bdev: *mut spdk_bdev) {
@@ -186,13 +190,13 @@ where
         unsafe { spdk_bdev_module_examine_done(T::module() as *mut _) }
     }
 
-    /// Examines the specified block device to determine whether it should be
-    /// claimed by a Virtual BDev implemented by this module.
+    /// Examines the specified block device to determine whether it should be claimed by a Virtual
+    /// BDev implemented by this module.
     ///
-    /// This function provides the second notification to a Virtual BDev module
-    /// to examine newly-added block devices and automatically create their own
-    /// Virtual BDevs. I/O may be submitted to the device in this function and
-    /// the decision whether to claim can be made asynchronously.
+    /// This function provides the second notification to a Virtual BDev module to examine
+    /// newly-added block devices and automatically create their own Virtual BDevs. I/O may be
+    /// submitted to the device in this function and the decision whether to claim can be made
+    /// asynchronously.
     ///
     /// The default implementation claims no devices.
     unsafe extern "C" fn examine_disk(bdev: *mut spdk_bdev) {

--- a/spdk/src/block/device.rs
+++ b/spdk/src/block/device.rs
@@ -14,11 +14,16 @@ use spdk_sys::{
     SPDK_BDEV_IO_TYPE_READ, SPDK_BDEV_IO_TYPE_RESET, SPDK_BDEV_IO_TYPE_SEEK_DATA,
     SPDK_BDEV_IO_TYPE_SEEK_HOLE, SPDK_BDEV_IO_TYPE_UNMAP, SPDK_BDEV_IO_TYPE_WRITE,
     SPDK_BDEV_IO_TYPE_WRITE_UNCORRECTABLE, SPDK_BDEV_IO_TYPE_WRITE_ZEROES, SPDK_BDEV_IO_TYPE_ZCOPY,
-    SPDK_BDEV_IO_TYPE_ZONE_APPEND, SPDK_BDEV_IO_TYPE_ZONE_MANAGEMENT, spdk_bdev, spdk_bdev_first,
-    spdk_bdev_get_block_size, spdk_bdev_get_buf_align, spdk_bdev_get_by_name, spdk_bdev_get_name,
-    spdk_bdev_get_num_blocks, spdk_bdev_get_optimal_io_boundary, spdk_bdev_get_physical_block_size,
+    SPDK_BDEV_IO_TYPE_ZONE_APPEND, SPDK_BDEV_IO_TYPE_ZONE_MANAGEMENT, SPDK_ENV_NUMA_ID_ANY,
+    spdk_bdev, spdk_bdev_first, spdk_bdev_get_block_size, spdk_bdev_get_buf_align,
+    spdk_bdev_get_by_name, spdk_bdev_get_dif_pi_format, spdk_bdev_get_dif_type,
+    spdk_bdev_get_md_size, spdk_bdev_get_name, spdk_bdev_get_num_blocks, spdk_bdev_get_numa_id,
+    spdk_bdev_get_optimal_io_boundary, spdk_bdev_get_physical_block_size,
     spdk_bdev_get_product_name, spdk_bdev_get_write_unit_size, spdk_bdev_has_write_cache,
-    spdk_bdev_io_type, spdk_bdev_io_type_supported, spdk_bdev_is_zoned, spdk_bdev_next,
+    spdk_bdev_io_type, spdk_bdev_io_type_supported, spdk_bdev_is_dif_check_enabled,
+    spdk_bdev_is_dif_head_of_md, spdk_bdev_is_md_interleaved, spdk_bdev_is_zoned, spdk_bdev_next,
+    spdk_dif_check_type, spdk_dif_pi_format,
+    spdk_dif_type::{self, SPDK_DIF_DISABLE},
 };
 
 use crate::{
@@ -104,22 +109,21 @@ unsafe impl<T: OwnedOps> Send for OwnershipState<T> {}
 
 /// Represents a block device.
 ///
-/// `Device` wraps an `spdk_bdev` pointer and can be in one of three ownership
-/// states: owned, borrowed, or none.
+/// `Device` wraps an `spdk_bdev` pointer and can be in one of three ownership states: owned,
+/// borrowed, or none.
 ///
-/// An owned device owns the underlying `spdk_bdev` pointer and will destroy it
-/// when dropped. The caller must ensure that the drop occurs in the same thread
-/// that created the device. It must also occur as part of thread event handling
-/// by explicitly calling [`task::yield_now`] before dropping the device.
-/// However, it is easiest and safest to explicitly call [`Device<T>::destroy`]
-/// on the device rather than let it drop naturally.
+/// An owned device owns the underlying `spdk_bdev` pointer and will destroy it when dropped. The
+/// caller must ensure that the drop occurs in the same thread that created the device. It must also
+/// occur as part of thread event handling by explicitly calling [`task::yield_now`] before dropping
+/// the device. However, it is easiest and safest to explicitly call [`Device<T>::destroy`] on the
+/// device rather than let it drop naturally.
 ///
-/// A borrowed device borrows the underlying `spdk_bdev` pointer. Dropping a
-/// borrowed device has no effect on the underlying `spdk_bdev` pointer.
+/// A borrowed device borrows the underlying `spdk_bdev` pointer. Dropping a borrowed device has no
+/// effect on the underlying `spdk_bdev` pointer.
 ///
-/// A device with no ownership state can only be safely queried for ownership
-/// state or dropped. Any other operation will panic. A device will be left in
-/// this state after the [`Device<T>::take`] method is called.
+/// A device with no ownership state can only be safely queried for ownership state or dropped. Any
+/// other operation will panic. A device will be left in this state after the [`Device<T>::take`]
+/// method is called.
 ///
 /// [`Device<T>::destroy`]: method@Device<T>::destroy
 /// [`Device<T>::take`]: method@Device<T>::take
@@ -139,8 +143,7 @@ impl<T: OwnedOps> Device<T> {
     ///
     /// # Returns
     ///
-    /// This function returns [`None`] if no block device with the given name
-    /// exists.
+    /// This function returns [`None`] if no block device with the given name exists.
     pub fn from_name(name: &CStr) -> Option<Device<Any>> {
         let bdev = unsafe { spdk_bdev_get_by_name(name.as_ptr()) };
 
@@ -179,8 +182,8 @@ impl<T: OwnedOps> Device<T> {
         }
     }
 
-    /// Consumes this device and returns a [`Device<Owned>`] assuming ownership
-    /// of the underlying `spdk_bdev` pointer.
+    /// Consumes this device and returns a [`Device<Owned>`] assuming ownership of the underlying
+    /// `spdk_bdev` pointer.
     pub fn into_owned(&mut self) -> Option<Device<Owned>> {
         match self.0 {
             OwnershipState::Owned(_) => match mem::replace(&mut self.0, OwnershipState::None) {
@@ -217,8 +220,7 @@ impl<T: OwnedOps> Device<T> {
         matches!(self.0, OwnershipState::None)
     }
 
-    /// Takes the value from this device and replaces with a value having no
-    /// ownership.
+    /// Takes the value from this device and replaces with a value having no ownership.
     pub fn take(&mut self) -> Self {
         mem::replace(self, Self(OwnershipState::None))
     }
@@ -227,9 +229,9 @@ impl<T: OwnedOps> Device<T> {
     ///
     /// # Returns
     ///
-    /// Only an owned device can be destroyed. This function returns `Err(EPERM)`
-    /// if called on a borrowed device and `Err(ENODEV)` if called on a device
-    /// that neither owns nor borrows the underlying `spdk_bdev` pointer.
+    /// Only an owned device can be destroyed. This function returns `Err(EPERM)` if called on a
+    /// borrowed device and `Err(ENODEV)` if called on a device that neither owns nor borrows the
+    /// underlying `spdk_bdev` pointer.
     pub async fn destroy(mut self) -> Result<()> {
         match self.0 {
             OwnershipState::Borrowed(_) => Err(EPERM),
@@ -273,17 +275,16 @@ impl<T: OwnedOps> Device<T> {
 
     /// Get the write unit size of this block device in logical blocks.
     ///
-    /// This is the minimum number of blocks that can be written in a single
-    /// operation. Write operations must be a multiple of the write unit size.
+    /// This is the minimum number of blocks that can be written in a single operation. Write
+    /// operations must be a multiple of the write unit size.
     pub fn write_unit_size(&self) -> u32 {
         unsafe { spdk_bdev_get_write_unit_size(self.as_ptr()) }
     }
 
     /// Get the optimal I/O boundary of this block device in logical blocks.
     ///
-    /// This is the optimal boundary in logical blocks that should not be
-    /// crosseed for best performance. This function returns `0` if there is
-    /// no optimal I/O boundary.
+    /// This is the optimal boundary in logical blocks that should not be crosseed for best
+    /// performance. This function returns `0` if there is no optimal I/O boundary.
     pub fn optimal_io_boundary(&self) -> u32 {
         unsafe { spdk_bdev_get_optimal_io_boundary(self.as_ptr()) }
     }
@@ -293,13 +294,86 @@ impl<T: OwnedOps> Device<T> {
         unsafe { spdk_bdev_get_buf_align(self.as_ptr()) }
     }
 
+    /// Get whether the metadata of this block device is interleaved with or separated from the
+    /// block data.
+    ///
+    /// The returned value if only meaningful if the metadata size is non-zero.
+    pub fn is_metadata_interleaved(&self) -> bool {
+        unsafe { spdk_bdev_is_md_interleaved(self.as_ptr()) }
+    }
+
+    /// Get the size of the metadata of this block device in bytes.
+    ///
+    /// A return value of zero indicates that this block device does not have metadata.
+    pub fn metadata_size(&self) -> u32 {
+        unsafe { spdk_bdev_get_md_size(self.as_ptr()) }
+    }
+
+    /// Get the [Data Integrity Field (DIF)] type of this block device.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn dif_type(&self) -> spdk_dif_type {
+        unsafe { spdk_bdev_get_dif_type(self.as_ptr()) }
+    }
+
+    /// Get the [Data Integrity Field (DIF)] protection information format of this block device.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(pi)` if DIF is enabled and `None` otherwise.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn dif_pi_format(&self) -> Option<spdk_dif_pi_format> {
+        if self.dif_type() != SPDK_DIF_DISABLE {
+            return Some(unsafe { spdk_bdev_get_dif_pi_format(self.as_ptr()) });
+        }
+
+        None
+    }
+
+    /// Get whether the specified [Data Integrity Field (DIF)] check is enabled.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn is_dif_check_enabled(&self, check_type: spdk_dif_check_type) -> bool {
+        unsafe { spdk_bdev_is_dif_check_enabled(self.as_ptr(), check_type) }
+    }
+
+    /// Get the bitmap of enabled [Data Integrity Field (DIF)] checks.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn dif_check_flags(&self) -> u32 {
+        unsafe { (*self.as_ptr()).dif_check_flags }
+    }
+
+    /// Get whether the [Data Integrity Field (DIF)] is set in the first 8|16 bytes or last 8|16
+    /// bytes of metadata.
+    ///
+    /// [Data Integrity Field (DIF)]: https://en.wikipedia.org/wiki/Data_Integrity_Field
+    pub fn is_dif_head_of_metadata(&self) -> bool {
+        unsafe { spdk_bdev_is_dif_head_of_md(self.as_ptr()) }
+    }
+
+    /// Get the NUMA node ID of this block device.
+    ///
+    /// # Returns
+    ///
+    /// The `Some(node_id)` or `None` if the ID is not known.
+    pub fn numa_id(&self) -> Option<i32> {
+        let node_id = unsafe { spdk_bdev_get_numa_id(self.as_ptr()) };
+
+        if node_id != SPDK_ENV_NUMA_ID_ANY {
+            return Some(node_id);
+        }
+
+        None
+    }
+
     /// Get the [`Layout`] for a buffer of the specified byte size.
     pub fn layout_for_size(&self, size: usize) -> std::result::Result<Layout, LayoutError> {
         Layout::from_size_align(size, self.buffer_alignment())
     }
 
-    /// Get the [`Layout`] for a buffer of the specified number of logical
-    /// blocks.
+    /// Get the [`Layout`] for a buffer of the specified number of logical blocks.
     pub fn layout_for_blocks(&self, count: u64) -> std::result::Result<Layout, LayoutError> {
         self.layout_for_size(count as usize * self.logical_block_size() as usize)
     }


### PR DESCRIPTION
This change also adds support for product name generation and customization, and in-place initialization of the `BDev` context.