### PR TITLE
chore: adds `define_error!` macro for `libanl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -330,9 +330,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fs_extra"
@@ -595,7 +595,17 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 name = "libanl"
 version = "0.1.0"
 dependencies = [
+ "libanl-macros",
  "libc",
+]
+
+[[package]]
+name = "libanl-macros"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["libanl","spdk", "spdk-macros", "spdk-sys"]
+members = ["libanl", "libanl-macros","spdk", "spdk-macros", "spdk-sys"]
 resolver = "2"

--- a/libanl-macros/Cargo.toml
+++ b/libanl-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "libanl-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+libc = "0.2.189"
+quote = "1.0.47"
+syn = { version = "3.0.3", features = ["full"] }

--- a/libanl-macros/src/define_error.rs
+++ b/libanl-macros/src/define_error.rs
@@ -1,0 +1,103 @@
+use std::ffi::CStr;
+
+use quote::{quote, quote_spanned};
+use syn::{
+    Expr, ExprAssign, Token,
+    parse::Parse,
+    parse_macro_input,
+    punctuated::{IntoIter, Punctuated},
+    spanned::Spanned,
+};
+
+struct ErrorList(Punctuated<ExprAssign, Token![,]>);
+
+impl IntoIterator for ErrorList {
+    type Item = ExprAssign;
+
+    type IntoIter = IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Parse for ErrorList {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self(Punctuated::<ExprAssign, Token![,]>::parse_terminated(
+            input,
+        )?))
+    }
+}
+
+pub(crate) struct DefineError {}
+
+impl DefineError {
+    /// Creates a new instance of `DefineError`.
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    /// Generates the `Error` constant definitions from a comma-delimited list of simple assignment
+    /// expressions in the form given by the regular expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`.
+    pub(crate) fn generate(&mut self, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+        let input = parse_macro_input!(item as ErrorList);
+        let (defs, errors): (_, _) = input
+            .into_iter()
+            .map(|e| {
+                let name = match &*e.left {
+                    Expr::Path(p) if p.path.segments.len() == 1 => {
+                        p.path.segments.first().unwrap().ident.clone()
+                    }
+                    _ => {
+                        return Err(
+                            syn::Error::new(e.left.span(), "expected a plain identifier")
+                                .to_compile_error(),
+                        );
+                    }
+                };
+
+                let val: i32 = match &*e.right {
+                    Expr::Unary(u) if matches!(u.op, syn::UnOp::Neg(_)) => {
+                        if let Expr::Lit(l) = &*u.expr
+                            && let syn::Lit::Int(l) = &l.lit
+                        {
+                            -l.base10_parse()
+                                .map_err(|e| syn::Error::to_compile_error(&e))?
+                        } else {
+                            return Err(syn::Error::new(
+                                e.right.span(),
+                                "expected a negative decimal value",
+                            )
+                            .to_compile_error());
+                        }
+                    }
+                    _ => {
+                        return Err(syn::Error::new(
+                            e.right.span(),
+                            "expected a negative unary value",
+                        )
+                        .to_compile_error());
+                    }
+                };
+
+                let msg = unsafe { &CStr::from_ptr(libc::gai_strerror(val)).to_string_lossy() };
+
+                Ok(quote_spanned! {e.span()=>
+                    #[doc = #msg]
+                    pub const #name: Error = Error(#val);
+
+                })
+            })
+            .partition::<Vec<_>, _>(Result::is_ok);
+
+        let defs = defs.into_iter().map(Result::ok);
+        let errors = errors.into_iter().map(Result::err);
+
+        let output = quote! {
+            #(#errors)*
+            #(#defs)*
+        };
+
+        output.into()
+    }
+}

--- a/libanl-macros/src/lib.rs
+++ b/libanl-macros/src/lib.rs
@@ -1,0 +1,23 @@
+use proc_macro::TokenStream;
+
+mod define_error;
+
+/// Generates `Error` constant definitions for the `libanl` crate.
+///
+/// The macro takes a comma-delimited list of simple expression assignments given by the regular
+/// expression, `((?P<name>\w+)\s+=\s+(?P<value>\d+),?)*`, and generates `Error` constant
+/// definitions. The definitions include automatically generated documentation by passing the value
+/// to the [`gai_strerror`] function.
+///
+/// <div class="warning">
+///
+/// **NOTE:** This macro is intended only for use by the `libanl` crate for its `Error` definitions.
+/// The macro defintion and usage is subject to change without notice.
+///
+/// </div>
+///
+/// [`gai_strerror`]: https://www.man7.org/linux/man-pages/man3/gai_strerror.3.html
+#[proc_macro]
+pub fn define_error(item: TokenStream) -> TokenStream {
+    define_error::DefineError::new().generate(item)
+}

--- a/libanl/Cargo.toml
+++ b/libanl/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 rust-version = "1.93.0"
 
 [dependencies]
+libanl-macros = { version = "0.1.0", path = "../libanl-macros" }
 libc = "0.2.189"

--- a/libanl/src/lib.rs
+++ b/libanl/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::{Debug, Display, Formatter},
 };
 
+use libanl_macros::define_error;
 use libc::{addrinfo, gai_strerror, sigevent, timespec};
 
 /// Specifies the Internet host and service to lookup in a call to the [`getaddrinfo_a`] function.
@@ -138,18 +139,20 @@ impl Debug for Error {
     }
 }
 
-pub const EAI_BADFLAGS: Error = Error(-1);
-pub const EAI_NONAME: Error = Error(-2);
-pub const EAI_AGAIN: Error = Error(-3);
-pub const EAI_FAIL: Error = Error(-4);
-pub const EAI_NODATA: Error = Error(-5);
-pub const EAI_FAMILY: Error = Error(-6);
-pub const EAI_SOCKTYPE: Error = Error(-7);
-pub const EAI_SERVICE: Error = Error(-8);
-pub const EAI_ADDRFAMILY: Error = Error(-9);
-pub const EAI_MEMORY: Error = Error(-10);
-pub const EAI_SYSTEM: Error = Error(-11);
-pub const EAI_INPROGRESS: Error = Error(-100);
+define_error! {
+    EAI_BADFLAGS = -1,
+    EAI_NONAME = -2,
+    EAI_AGAIN = -3,
+    EAI_FAIL = -4,
+    EAI_NODATA = -5,
+    EAI_FAMILY = -6,
+    EAI_SOCKTYPE = -7,
+    EAI_SERVICE = -8,
+    EAI_ADDRFAMILY = -9,
+    EAI_MEMORY = -10,
+    EAI_SYSTEM = -11,
+    EAI_INPROGRESS = -100,
+}
 
 /// Converts the return value from a `getaddrinfo` family function into an
 /// [`Error`] value.

--- a/spdk-sys/Cargo.toml
+++ b/spdk-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "spdk"
 [build-dependencies]
 autotools = "0.2.7"
 bindgen = { version = "0.72.1", features = ["experimental"] }
-cc = "1.4.0"
+cc = "1.4.1"
 doxygen-rs = "0.4.2"
 fs_extra = "1.3.0"
 itertools = "0.15.0"


### PR DESCRIPTION
This change adds a `define_error!` macro to simplify `Error` constant definition with automatically generated documentation.